### PR TITLE
Get-VCFCredential support for resourceType 

### DIFF
--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -1322,7 +1322,10 @@ Function Get-VCFCredential {
             [string]$privilegedPassword,
 		[Parameter (Mandatory=$false)]
             [ValidateNotNullOrEmpty()]
-            [string]$resourceName
+            [string]$resourceName,
+        [Parameter (Mandatory=$false)]
+            [ValidateNotNullOrEmpty()]
+            [string]$resourceType   
     )
 
     $headers = @{"Accept" = "application/json"}
@@ -1331,16 +1334,24 @@ Function Get-VCFCredential {
     $headers.Add("privileged-password", "$privilegedPassword")
 
     if ($PsBoundParameters.ContainsKey("resourceName")) {
+
+        $uri = "https://$sddcManager/v1/credentials?resourceName=$resourceName"
+    
+    }
+    # if requesting by resource type then resourceName must be empty
+    if ($PsBoundParameters.ContainsKey("resourceType") -and (-not $PsBoundParameters.ContainsKey("resourceName"))) {
+
         $uri = "https://$sddcManager/v1/credentials?resourceName=$resourceName"
     }
     else {
+
         $uri = "https://$sddcManager/v1/credentials"
     }
-    try {
+    Try {
 	    $response = Invoke-RestMethod -Method GET -URI $uri -headers $headers
 	    $response
     }
-    catch {
+    Catch {
         #Get response from the exception
         ResponseExeception
     }

--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -1297,19 +1297,23 @@ Function Get-VCFCredential {
 <#
     .SYNOPSIS
     Connects to the specified SDDC Manager and retrieves a list of credentials.
+    Supported resource types are: PSC, VCENTER, ESXI, NSX_MANAGER, NSX_CONTROLLER, BACKUP
+    Please note: if you are requesting credentials by resource type then the resource name parameter (if passed) will be ignored (they are mutually exclusive)
 
     .DESCRIPTION
     The Get-VCFCredential cmdlet connects to the specified SDDC Manager and retrieves a list of
     credentials. A privileged user account is required.
 
     .EXAMPLE
-    PS C:\> Get-VCFCredential -privilegedUsername sec-admin@rainpole.local
-	-privilegedPassword VMw@re1!
+    PS C:\> Get-VCFCredential -privilegedUsername sec-admin@rainpole.local -privilegedPassword VMw@re1!
     This example shows how to get a list of credentials
 
+    .EXAMPLE
+    PS C:\> Get-VCFCredential -privilegedUsername sec-admin@rainpole.local -privilegedPassword VMw@re1! -resourceType PSC
+    This example shows how to get a list of PSC credentials
+
 	.EXAMPLE
-    PS C:\> Get-VCFCredential -privilegedUsername sec-admin@rainpole.local
-	-privilegedPassword VMw@re1! -resourceName sfo01m01esx01.sfo.rainpole.local
+    PS C:\> Get-VCFCredential -privilegedUsername sec-admin@rainpole.local -privilegedPassword VMw@re1! -resourceName sfo01m01esx01.sfo.rainpole.local
     This example shows how to get the credential for a specific resourceName (FQDN)
 #>
 
@@ -1317,13 +1321,17 @@ Function Get-VCFCredential {
         [Parameter (Mandatory=$true)]
             [ValidateNotNullOrEmpty()]
             [string]$privilegedUsername,
+
 		[Parameter (Mandatory=$true)]
             [ValidateNotNullOrEmpty()]
             [string]$privilegedPassword,
+
 		[Parameter (Mandatory=$false)]
             [ValidateNotNullOrEmpty()]
             [string]$resourceName,
+
         [Parameter (Mandatory=$false)]
+            [ValidateSet("PSC", "VCENTER", "ESXI", "NSX_MANAGER", "NSX_CONTROLLER", "BACKUP")]
             [ValidateNotNullOrEmpty()]
             [string]$resourceType   
     )
@@ -1338,10 +1346,10 @@ Function Get-VCFCredential {
         $uri = "https://$sddcManager/v1/credentials?resourceName=$resourceName"
     
     }
-    # if requesting by resource type then resourceName must be empty
-    if ($PsBoundParameters.ContainsKey("resourceType") -and (-not $PsBoundParameters.ContainsKey("resourceName"))) {
+    # if requesting credential by type then name is ignored (mutually exclusive)
+    if ($PsBoundParameters.ContainsKey("resourceType") ) {
 
-        $uri = "https://$sddcManager/v1/credentials?resourceName=$resourceName"
+        $uri = "https://$sddcManager/v1/credentials?resourceType=$resourceType"
     }
     else {
 

--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -1346,15 +1346,15 @@ Function Get-VCFCredential {
         $uri = "https://$sddcManager/v1/credentials?resourceName=$resourceName"
     
     }
+    else {
+        $uri = "https://$sddcManager/v1/credentials"
+    }
     # if requesting credential by type then name is ignored (mutually exclusive)
     if ($PsBoundParameters.ContainsKey("resourceType") ) {
 
         $uri = "https://$sddcManager/v1/credentials?resourceType=$resourceType"
     }
-    else {
 
-        $uri = "https://$sddcManager/v1/credentials"
-    }
     Try {
 	    $response = Invoke-RestMethod -Method GET -URI $uri -headers $headers
 	    $response


### PR DESCRIPTION
Get-VCFCredential added support for resource type
Supported resource types are: PSC, VCENTER, ESXI, NSX_MANAGER, NSX_CONTROLLER, BACKUP