### PR TITLE
Invoke-VCFCommand

### DIFF
--- a/docs/functions/Host/Invoke-VCFCommand.md
+++ b/docs/functions/Host/Invoke-VCFCommand.md
@@ -1,0 +1,82 @@
+# Invoke-VCFCommand
+
+
+ [Parameter (Mandatory=$false)]
+            [ValidateNotNullOrEmpty()]
+            [String] $vcfPassword,
+    
+            [Parameter (Mandatory=$false)]
+            [ValidateNotNullOrEmpty()]
+            [String] $rootPassword,
+    
+            [Parameter (Mandatory=$true)]
+            [ValidateSet("
+            [String] $sosOption
+        
+
+### Synopsis
+Connects to the specified SDDC Manager using SSH and invoke SSH commands (SOS)
+
+### Description
+The Invoke-VCFCommand cmdlet connects to the specified SDDC Manager via SSH using vcf user and subsequently 
+execute elevated SOS commands using the root account. Bboth vcf and root password are mandatory parameters.
+If passwords are not passed as parameters it will prompt for them.
+
+### Examples
+#### Example 1
+```
+Connect-VCFCommand -vcfpassword VMware1! -rootPassword VMware1! -sosOption general-health
+```
+This example will execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
+
+#### Example 2
+```
+Connect-VCFCommand -sosOption general-health
+```
+This example will ask for vcf and root password to the user and then execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
+
+### Parameters
+
+#### -vcfPassword
+Password for the vcf user to establish the SSH connection
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+```
+
+#### -rootPassword
+root password of SDDC Manager, required to execute sudo commands
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+```
+
+#### -sosOption
+List of SoS options to pass as parameter to /opt/vmware/sddc-support/sos
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accepted value: general-health, compute-health, ntp-health, password-health, get-vcf-summary, get-inventory-info, get-host-ips, get-vcf-services-summary
+```
+
+### Notes
+
+### Related Links

--- a/docs/functions/Host/Invoke-VCFCommand.md
+++ b/docs/functions/Host/Invoke-VCFCommand.md
@@ -1,19 +1,5 @@
 # Invoke-VCFCommand
 
-
- [Parameter (Mandatory=$false)]
-            [ValidateNotNullOrEmpty()]
-            [String] $vcfPassword,
-    
-            [Parameter (Mandatory=$false)]
-            [ValidateNotNullOrEmpty()]
-            [String] $rootPassword,
-    
-            [Parameter (Mandatory=$true)]
-            [ValidateSet("
-            [String] $sosOption
-        
-
 ### Synopsis
 Connects to the specified SDDC Manager using SSH and invoke SSH commands (SOS)
 

--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -311,14 +311,123 @@ Function Decommission-VCFHost {
 }
 Export-ModuleMember -Function Decommission-VCFHost
 
-#TODO: Add Posh-SSH Support
-Function Cleanup-VCFHosts {
-# Print Instructions to screen
-Write-Output "Not Implemented as a function yet as it requires SSH access to SDDC Manager"
-Write-Output "SSH to $sddcManager"
-Write-Output "Run /opt/vmware/sddc-support/sos --cleanup-host ALL"
+Function Invoke-VCFCommand {
+    <#
+        .SYNOPSIS
+        Connects to the specified SDDC Manager using SSH and invoke SSH commands (SOS)
+    
+        .DESCRIPTION
+        The Invoke-VCFCommand cmdlet connects to the specified SDDC Manager via SSH using vcf user and subsequently 
+        execute elevated SOS commands using the root account. Bboth vcf and root password are mandatory parameters.
+            If passwords are not passed as parameters it will prompt for them.
+    
+        .EXAMPLE
+        PS C:\> Connect-VCFCommand -vcfpassword VMware1! -rootPassword VMware1! -sosOption general-health 
+        This example will execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
+    
+        .EXAMPLE
+        PS C:\> Connect-VCFCommand -sosOption general-health 
+        This example will ask for vcf and root password to the user and then execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
+    
+    #>
+    
+        param (
+           
+            [Parameter (Mandatory=$false)]
+            [ValidateNotNullOrEmpty()]
+            [String] $vcfPassword,
+    
+            [Parameter (Mandatory=$false)]
+            [ValidateNotNullOrEmpty()]
+            [String] $rootPassword,
+    
+            [Parameter (Mandatory=$true)]
+            [ValidateSet("general-health","compute-health","ntp-health","password-health","get-vcf-summary","get-inventory-info","get-host-ips","get-vcf-services-summary")]
+            [String] $sosOption
+        )
+    
+        # POSH module is required, if not present skipping
+        $poshSSH = Resolve-PSModule -moduleName "Posh-SSH"
+    
+        if ($poshSSH -eq "ALREADY_IMPORTED" -or $poshSSH -eq "IMPORTED" -or $poshSSH -eq "INSTALLED_IMPORTED") {
+            
+            # Expected sudo prompt from SDDC Manager for elevated commands
+            $sudoPrompt = "[sudo] password for vcf"
+    
+            # validate if the SDDC Manager vcf password parameter is passed, if not prompt the user and then build vcfCreds PSCredential object
+            if ( -not $PsBoundParameters.ContainsKey("vcfPassword") ) {
+                Write-Host "Please provide the SDDC Manager vcf user password:" -ForegroundColor Green
+                $vcfSecuredPassword = Read-Host -AsSecureString
+                $vcfCred = New-Object System.Management.Automation.PSCredential ('vcf', $vcfSecuredPassword)
+            }
+            else {
+                # Convert the clear text input password to secure string 
+                $vcfSecuredPassword = ConvertTo-SecureString $vcfPassword -AsPlainText -Force
+                # build credential object
+                $vcfCred = New-Object System.Management.Automation.PSCredential ('vcf', $vcfSecuredPassword)
+            }
+            
+            # validate if the SDDC Manager root password parameter is passed, if not prompt the user and then build rootCreds PSCredential object
+            if ( -not $PsBoundParameters.ContainsKey("rootPassword") ) {
+                Write-Host "Please provide the root credential to execute elevated commands in SDDC Manager:" -ForegroundColor Green
+                $rootSecuredPassword = Read-Host -AsSecureString
+                $rootCred = New-Object System.Management.Automation.PSCredential ('root', $rootSecuredPassword)
+            }
+            else {
+                # Convert the clear text input password to secure string 
+                $rootSecuredPassword = ConvertTo-SecureString $rootPassword -AsPlainText -Force
+                # build credential object
+                $rootCred = New-Object System.Management.Automation.PSCredential ('root', $rootSecuredPassword)
+            }
+    
+            # depending on the SoS command there will be a different pattern to match at the end of the ssh stream output
+            switch ($sosOption) {
+                "general-health"        { $sosEndMessage = "For detailed report" }
+                "compute-health"        { $sosEndMessage = "Health Check completed" }
+                "ntp-health"            { $sosEndMessage = "For detailed report" }
+                "password-health"       { $sosEndMessage = "completed"  }
+                "get-inventory-info"    { $sosEndMessage = "Health Check completed" }
+                "get-vcf-summary"       { $sosEndMessage = "SOLUTIONS_MANAGER" }
+                "get-host-ips"          { $sosEndMessage = "Health Check completed" }
+                "get-vcf-services-summary" { $sosEndMessage = "VCF SDDC Manager Uptime" }
+            }
+    
+            # Create SSH session to SDDC Manager using vcf user (can't ssh as root by default)
+            Try {
+                $sessionSSH = New-SSHSession -Computer $sddcManager -Credential $vcfCred -AcceptKey
+            }
+            Catch {
+                ResponseExeception
+            }
+    
+            if ($sessionSSH.Connected -eq "True") {
+                $stream = $SessionSSH.Session.CreateShellStream("PS-SSH", 0, 0, 0, 0, 1000)
+            
+                # build the SOS command to run
+                $sshCommand = "sudo /opt/vmware/sddc-support/sos " + "--" + $sosOption
+                # Invoke the SSH stream command
+                $outInvoke = Invoke-SSHStreamExpectSecureAction -ShellStream $stream -Command $sshCommand -ExpectString $sudoPrompt -SecureAction $rootCred.Password
+                    
+                    if ($outInvoke) {
+                        Write-Host ""
+                        Write-Host "Executing the remote SoS command, output will display when the the run is completed. This might take a while, please wait..."
+                        Write-Host ""
+                        $stream.Expect($sosEndMessage)
+                    }
+                    # distroy the connection previously established
+                    Remove-SSHSession -SessionId $sessionSSH.SessionId | Out-Null
+            }        
+        }
+        else {
+    
+            Write-Host ""
+            Write-Host "PowerShell Module Posh-SSH staus is: $poshSSH. Posh-SSH is required to execute this cmdlet, please install the module and try again." -ForegroundColor Yellow
+            Write-Host ""
+        
+        }
+}
+Export-ModuleMember -Function Invoke-VCFCommand
 
-				}
 ######### End Host Operations ##########
 
 


### PR DESCRIPTION
This PR include two new functions:
**Resolve-PSModule**

**Invoke-VCFCommand** in this initial version supports the following SoS options:
- general-health
- compute-health
- ntp-health
- password-health
- get-vcf-summary
- get-inventory-info
- get-host-ips
- get-vcf-services-summary