### PR TITLE
fixed Get-VCFVersion

### DIFF
--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -2821,9 +2821,10 @@ Function ResponseExeception {
 }
 
 Function CheckVCFVersion {
-    [string]$getvcfVersion = Get-VCFManager | Select version
-    $vcfVersion = $getvcfVersion.substring(10,3)
-    if ($vcfVersion -ne "3.9") {
+    
+    $vcfManager = Get-VCFManager
+    
+    if ($vcfManager.version.Substring(0,3) -ne "3.9") {
         Write-Host ""
         Write-Host "This cmdlet is only supported in VCF 3.9 or later" -ForegroundColor Magenta
         Write-Host ""


### PR DESCRIPTION
the Select statement was not required and was causing .Substring to fail. Also it had a wrong substring index