### PR TITLE
Invoke-VCFCommand fix + Get-VCFVersion fix

### DIFF
--- a/docs/functions/Host/Invoke-VCFCommand.md
+++ b/docs/functions/Host/Invoke-VCFCommand.md
@@ -5,19 +5,19 @@ Connects to the specified SDDC Manager using SSH and invoke SSH commands (SOS)
 
 ### Description
 The Invoke-VCFCommand cmdlet connects to the specified SDDC Manager via SSH using vcf user and subsequently 
-execute elevated SOS commands using the root account. Bboth vcf and root password are mandatory parameters.
+execute elevated SOS commands using the root account. Both vcf and root password are mandatory parameters.
 If passwords are not passed as parameters it will prompt for them.
 
 ### Examples
 #### Example 1
 ```
-Connect-VCFCommand -vcfpassword VMware1! -rootPassword VMware1! -sosOption general-health
+Invoke-VCFCommand -vcfpassword VMware1! -rootPassword VMware1! -sosOption general-health
 ```
 This example will execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
 
 #### Example 2
 ```
-Connect-VCFCommand -sosOption general-health
+Invoke-VCFCommand -sosOption general-health
 ```
 This example will ask for vcf and root password to the user and then execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
 

--- a/docs/functions/Host/Invoke-VCFCommand.md
+++ b/docs/functions/Host/Invoke-VCFCommand.md
@@ -1,0 +1,68 @@
+# Invoke-VCFCommand
+
+### Synopsis
+Connects to the specified SDDC Manager using SSH and invoke SSH commands (SOS)
+
+### Description
+The Invoke-VCFCommand cmdlet connects to the specified SDDC Manager via SSH using vcf user and subsequently 
+execute elevated SOS commands using the root account. Bboth vcf and root password are mandatory parameters.
+If passwords are not passed as parameters it will prompt for them.
+
+### Examples
+#### Example 1
+```
+Connect-VCFCommand -vcfpassword VMware1! -rootPassword VMware1! -sosOption general-health
+```
+This example will execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
+
+#### Example 2
+```
+Connect-VCFCommand -sosOption general-health
+```
+This example will ask for vcf and root password to the user and then execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
+
+### Parameters
+
+#### -vcfPassword
+Password for the vcf user to establish the SSH connection
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+```
+
+#### -rootPassword
+root password of SDDC Manager, required to execute sudo commands
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+```
+
+#### -sosOption
+List of SoS options to pass as parameter to /opt/vmware/sddc-support/sos
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accepted value: general-health, compute-health, ntp-health, password-health, get-vcf-summary, get-inventory-info, get-host-ips, get-vcf-services-summary
+```
+
+### Notes
+
+### Related Links

--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -3043,9 +3043,10 @@ Function ResponseExeception {
 }
 
 Function CheckVCFVersion {
-    [string]$getvcfVersion = Get-VCFManager | Select version
-    $vcfVersion = $getvcfVersion.substring(10,3)
-    if ($vcfVersion -lt "3.9") {
+    
+    $vcfManager = Get-VCFManager
+	
+    if ($vcfManager.version.Substring(0,3) -ne "3.9") {
         Write-Host ""
         Write-Host "This cmdlet is only supported in VCF 3.9 or later" -ForegroundColor Magenta
         Write-Host ""

--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -2570,7 +2570,7 @@ Function Invoke-VCFCommand {
         This example will execute and display the output of "/opt/vmware/sddc-support/sos --general-health"
     
         .EXAMPLE
-        PS C:\> Connect-VCFCommand -sosOption general-health 
+        PS C:\> Invoke-VCFCommand -sosOption general-health 
         This example will ask for vcf and root password to the user and then execute and display the output of "/opt/vmware/sddc-support/sos --general-health"
     
     #>

--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -2558,7 +2558,7 @@ Export-ModuleMember -Function Get-VCFvRLI
 Function Invoke-VCFCommand {
     <#
         .SYNOPSIS
-        Connects to the specified SDDC Manager using SSH and invoke SSH commands (SOS)
+        Connects to the specified SDDC Manager using SSH and invoke SSH commands (SoS)
     
         .DESCRIPTION
         The Invoke-VCFCommand cmdlet connects to the specified SDDC Manager via SSH using vcf user and subsequently 
@@ -2566,7 +2566,7 @@ Function Invoke-VCFCommand {
             If passwords are not passed as parameters it will prompt for them.
     
         .EXAMPLE
-        PS C:\> Connect-VCFCommand -vcfpassword VMware1! -rootPassword VMware1! -sosOption general-health 
+        PS C:\> Invoke-VCFCommand -vcfpassword VMware1! -rootPassword VMware1! -sosOption general-health 
         This example will execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
     
         .EXAMPLE

--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -2561,25 +2561,21 @@ Function Invoke-VCFCommand {
         Connects to the specified SDDC Manager using SSH and invoke SSH commands (SOS)
     
         .DESCRIPTION
-        The Invoke-VCFCommand cmdlet connects to the specified SDDC Manager via SSH using vcf user and 
-        subsequently execute elevated SOS commands using the root account. This is why both vcf and root password are
-        mandatory parameters. If passwords are not passed as parameters it will prompt for them.
+        The Invoke-VCFCommand cmdlet connects to the specified SDDC Manager via SSH using vcf user and subsequently 
+        execute elevated SOS commands using the root account. Bboth vcf and root password are mandatory parameters.
+            If passwords are not passed as parameters it will prompt for them.
     
         .EXAMPLE
-        PS C:\> Connect-VCFCommand -fqdn sfo01vcf01.sfo.rainpole.local -vcfpassword VMware1! -rootPassword VMware1! -sosOption general-health 
+        PS C:\> Connect-VCFCommand -vcfpassword VMware1! -rootPassword VMware1! -sosOption general-health 
         This example will execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
     
         .EXAMPLE
-        PS C:\> Connect-VCFCommand -fqdn sfo01vcf01.sfo.rainpole.local -sosOption general-health 
+        PS C:\> Connect-VCFCommand -sosOption general-health 
         This example will ask for vcf and root password to the user and then execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
     
     #>
     
         param (
-    
-            [Parameter (Mandatory=$true)]
-            [ValidateNotNullOrEmpty()]
-            [string]$fqdn,
            
             [Parameter (Mandatory=$false)]
             [ValidateNotNullOrEmpty()]
@@ -2589,19 +2585,11 @@ Function Invoke-VCFCommand {
             [ValidateNotNullOrEmpty()]
             [String] $rootPassword,
     
-            [Parameter (Mandatory=$false)]
-            [ValidateNotNullOrEmpty()]
-            [String] $privilegedUsername,
-    
-            [Parameter (Mandatory=$false)]
-            [ValidateNotNullOrEmpty()]
-            [String] $privilegedPassword,
-    
             [Parameter (Mandatory=$true)]
-            [ValidateSet("general-health","ntp-health","password-health","get-vcf-summary","get-file","cleanup-host")]
+            [ValidateSet("general-health","compute-health","ntp-health","password-health","get-vcf-summary","get-inventory-info","get-host-ips","get-vcf-services-summary")]
             [String] $sosOption
-    
         )
+    
         # POSH module is required, if not present skipping
         $poshSSH = Resolve-PSModule -moduleName "Posh-SSH"
     
@@ -2609,82 +2597,79 @@ Function Invoke-VCFCommand {
             
             # Expected sudo prompt from SDDC Manager for elevated commands
             $sudoPrompt = "[sudo] password for vcf"
-            
+    
             # validate if the SDDC Manager vcf password parameter is passed, if not prompt the user and then build vcfCreds PSCredential object
             if ( -not $PsBoundParameters.ContainsKey("vcfPassword") ) {
                 Write-Host "Please provide the SDDC Manager vcf user password:" -ForegroundColor Green
                 $vcfSecuredPassword = Read-Host -AsSecureString
-                $vcfCreds = New-Object System.Management.Automation.PSCredential ('vcf', $vcfSecuredPassword)
+                $vcfCred = New-Object System.Management.Automation.PSCredential ('vcf', $vcfSecuredPassword)
             }
             else {
                 # Convert the clear text input password to secure string 
                 $vcfSecuredPassword = ConvertTo-SecureString $vcfPassword -AsPlainText -Force
                 # build credential object
-                $vcfCreds = New-Object System.Management.Automation.PSCredential ('vcf', $vcfSecuredPassword)
+                $vcfCred = New-Object System.Management.Automation.PSCredential ('vcf', $vcfSecuredPassword)
             }
             
             # validate if the SDDC Manager root password parameter is passed, if not prompt the user and then build rootCreds PSCredential object
             if ( -not $PsBoundParameters.ContainsKey("rootPassword") ) {
                 Write-Host "Please provide the root credential to execute elevated commands in SDDC Manager:" -ForegroundColor Green
                 $rootSecuredPassword = Read-Host -AsSecureString
-                $rootCreds = New-Object System.Management.Automation.PSCredential ('root', $rootSecuredPassword)
+                $rootCred = New-Object System.Management.Automation.PSCredential ('root', $rootSecuredPassword)
             }
             else {
                 # Convert the clear text input password to secure string 
                 $rootSecuredPassword = ConvertTo-SecureString $rootPassword -AsPlainText -Force
                 # build credential object
-                $rootCreds = New-Object System.Management.Automation.PSCredential ('root', $rootSecuredPassword)
+                $rootCred = New-Object System.Management.Automation.PSCredential ('root', $rootSecuredPassword)
             }
     
-            # depending on the SOS command there will be a different pattern to match at the end of the stream (ssh output)
+            # depending on the SoS command there will be a different pattern to match at the end of the ssh stream output
             switch ($sosOption) {
-                "general-health"    { $sosEndMessage = "For detailed report" }
-                "ntp-health"        { $sosEndMessage = "For detailed report" }
-                "password-health"   { $sosEndMessage = "completed"  }
-                "get-file"          { $sosEndMessage = "Log Collection completed" }
-                "get-vcf-summary"   { $sosEndMessage = "SOLUTIONS_MANAGER" }
+                "general-health"        { $sosEndMessage = "For detailed report" }
+                "compute-health"        { $sosEndMessage = "Health Check completed" }
+                "ntp-health"            { $sosEndMessage = "For detailed report" }
+                "password-health"       { $sosEndMessage = "completed"  }
+                "get-inventory-info"    { $sosEndMessage = "Health Check completed" }
+                "get-vcf-summary"       { $sosEndMessage = "SOLUTIONS_MANAGER" }
+                "get-host-ips"          { $sosEndMessage = "Health Check completed" }
+                "get-vcf-services-summary" { $sosEndMessage = "VCF SDDC Manager Uptime" }
             }
     
             # Create SSH session to SDDC Manager using vcf user (can't ssh as root by default)
-            $sessionSSH = New-SSHSession -Computer $fqdn -Credential $vcfCreds -AcceptKey
+            Try {
+                $sessionSSH = New-SSHSession -Computer $sddcManager -Credential $vcfCred -AcceptKey
+            }
+            Catch {
+                ResponseExeception
+            }
     
-            # Create the SSH stream
-            $stream = $SessionSSH.Session.CreateShellStream("PS-SSH", 0, 0, 0, 0, 1000)
+            if ($sessionSSH.Connected -eq "True") {
+                $stream = $SessionSSH.Session.CreateShellStream("PS-SSH", 0, 0, 0, 0, 1000)
             
-            if ($sosOption -eq "get-file") {
-                # testing log extration
-                # /var/log/vmware/vcf/sddc-support/sos-2020-01-14-23-20-30-2236
-                $path = "C:\TFTP-Root\sos-2020-01-14-23-20-30-2236"
-                if (!(Test-Path $path)) {
-                    New-Item -ItemType Directory -Path $path
-                }
-                Get-SCPFolder -ComputerName $fqdn -Credential $vcfCreds -LocalFolder $path -RemoteFolder '/var/log/vmware/vcf/sddc-support/sos-2020-01-14-23-20-30-2236'
-            }
-            elseif ($sosOption -eq "cleanup-host") {
-                Cleanup-VCFHosts
-            }
-            else {
                 # build the SOS command to run
                 $sshCommand = "sudo /opt/vmware/sddc-support/sos " + "--" + $sosOption
                 # Invoke the SSH stream command
-                $outInvoke = Invoke-SSHStreamExpectSecureAction -ShellStream $stream -Command $sshCommand -ExpectString $sudoPrompt -SecureAction $rootCreds.Password
-                
-                if ($outInvoke) {
-                    Write-Host ""
-                    Write-Host "Waiting for the command to finish running before displaying the output, this might take a while..."
-                    Write-Host ""
-                    $stream.Expect($sosEndMessage)
-                }
-                # remove the connection previously established
-                Remove-SSHSession -SessionId $sessionSSH.SessionId | Out-Null
-            }
+                $outInvoke = Invoke-SSHStreamExpectSecureAction -ShellStream $stream -Command $sshCommand -ExpectString $sudoPrompt -SecureAction $rootCred.Password
+                    
+                    if ($outInvoke) {
+                        Write-Host ""
+                        Write-Host "Executing the remote SoS command, output will display when the the run is completed. This might take a while, please wait..."
+                        Write-Host ""
+                        $stream.Expect($sosEndMessage)
+                    }
+                    # distroy the connection previously established
+                    Remove-SSHSession -SessionId $sessionSSH.SessionId | Out-Null
+            }        
         }
         else {
     
+            Write-Host ""
             Write-Host "PowerShell Module Posh-SSH staus is: $poshSSH. Posh-SSH is required to execute this cmdlet, please install the module and try again." -ForegroundColor Yellow
+            Write-Host ""
         
         }
-    }
+}
 Export-ModuleMember -Function Invoke-VCFCommand
 
 ######### End Foundation Component Operations ##########

--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -3023,6 +3023,7 @@ Function Remove-VCFFederation {
 
 ######### End Federation Management ##########
 
+######### Start Utility Functions (not exported) ##########
 Function ResponseExeception {
     #Get response from the exception
     $response = $_.exception.response
@@ -3053,3 +3054,80 @@ Function CheckVCFVersion {
         break
     }
 }
+
+
+
+Function Resolve-PSModule {
+    <# 
+        .SYNOPSIS
+        Check for a PowerShell module presence, if not there try to import/install it.
+    
+        .DESCRIPTION
+        This function is not exported. The idea is to use the return searchResult from the caller function to establish 
+        if we can proceed to the next step where the module will be required (developed to check on Posh-SSH).
+        Logic:
+            - Check if module is imported into the current session
+            - If module is not imported, check if available on disk and try to import
+            - If module is not imported & not available on disk, try PSGallery then install and import
+            - If module is not imported, not available and not in online gallery then abort
+        
+            Informing user only if the module needs importing/installing. If the module is already present nothing will be displayed.
+    
+        .EXAMPLE
+        PS C:\> $poshSSH = Resolve-PSModule -moduleName "Posh-SSH" 
+        This example will check if the current PS module session has Posh-SSH installed, if not will try to install it
+    
+    #>
+        param (
+            [Parameter (Mandatory=$true)]
+            [ValidateNotNullOrEmpty()]
+            [string]$moduleName
+        )
+    
+        # check if module is imported into the current session
+        if (Get-Module -Name $moduleName) {
+            $searchResult = "ALREADY_IMPORTED"
+        }
+        else {
+            # If module is not imported, check if available on disk and try to import
+            if (Get-Module -ListAvailable | Where-Object {$_.Name -eq $moduleName}) {
+                Try { 
+                    Write-Host ""
+                    Write-Host "Module $moduleName not loaded, importing now please wait..."
+                    Import-Module $moduleName
+                    Write-Host "Module $moduleName imported successfully."
+                    $searchResult = "IMPORTED"
+                }
+                Catch {
+                    #Write-Host "There has been a problem trying to install and import the module $moduleName"
+                    #Write-Host "The error message is:" $_.Exception.Message -ForegroundColor Red
+                    $searchResult = "IMPORT_FAILED"
+                }
+            }
+            else {
+                # If module is not imported & not available on disk, try PSGallery then install and import
+                if (Find-Module -Name $moduleName | Where-Object {$_.Name -eq $moduleName}) {
+                    Try {
+                        Write-Host ""
+                        Write-Host "Module $moduleName was missing, installing now please wait..."
+                        Install-Module -Name $moduleName -Force -Scope CurrentUser
+                        Write-Host "Importing module $moduleName, please wait..."
+                        Import-Module $moduleName
+                        Write-Host "Module $moduleName installed and imported"
+                        $searchResult = "INSTALLED_IMPORTED"
+    
+                    }
+                    Catch {
+                        $searchResult = "INSTALLIMPORT_FAILED"
+                    }
+                }
+                else {
+                    # If module is not imported, not available and not in online gallery then abort
+                    $searchResult = "NOTAVAILABLE"
+                }
+            }
+        }
+    return $searchResult
+}
+
+######### End Utility Functions (not exported) ##########

--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -2570,7 +2570,7 @@ Function Invoke-VCFCommand {
         This example will execute and display the output of "/opt/vmware/sddc-support/sos --general-health"
     
         .EXAMPLE
-        PS C:\> Invoke-VCFCommand -sosOption general-health 
+        PS C:\> Invoke-VCFCommand -sosOption general-health
         This example will ask for vcf and root password to the user and then execute and display the output of "/opt/vmware/sddc-support/sos --general-health"
     
     #>

--- a/powerVCF.psm1
+++ b/powerVCF.psm1
@@ -2562,16 +2562,16 @@ Function Invoke-VCFCommand {
     
         .DESCRIPTION
         The Invoke-VCFCommand cmdlet connects to the specified SDDC Manager via SSH using vcf user and subsequently 
-        execute elevated SOS commands using the root account. Bboth vcf and root password are mandatory parameters.
-            If passwords are not passed as parameters it will prompt for them.
+        execute elevated SOS commands using the root account. Both vcf and root password are mandatory parameters.
+        If passwords are not passed as parameters it will prompt for them.
     
         .EXAMPLE
         PS C:\> Invoke-VCFCommand -vcfpassword VMware1! -rootPassword VMware1! -sosOption general-health 
-        This example will execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
+        This example will execute and display the output of "/opt/vmware/sddc-support/sos --general-health"
     
         .EXAMPLE
         PS C:\> Connect-VCFCommand -sosOption general-health 
-        This example will ask for vcf and root password to the user and then execute and display the output of "/opt/vmware/sddc-support/sos --general-health" command
+        This example will ask for vcf and root password to the user and then execute and display the output of "/opt/vmware/sddc-support/sos --general-health"
     
     #>
     


### PR DESCRIPTION
Summary of the commits included in this PR:

- Get-VCFVersion (FIX): had Select statement which was causing substring method to fail + wrong substring index was used
- Resolve-PSModule (NEW): required by Invoke-VCFCommand
- Invoke-VCFCommand (ENHANCED): new SoS options + bug fix
- Invoke-VCFCommand markdown documentation (NEW) + typos fixed 