### PR TITLE
Add Version Check for Federation Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Updated `Get-VCFFederationMember` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
 - Updated `New-VCFFederationInvite` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
 - Updated `Join-VCFFederation` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
-
+- Updated `Get-VCFFederationTask` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
 
 ## v2.1.7 (2021-30-11)
 - Fixed `New-VCFCluster`cmdlet where incorrect braces prevented the ability to retrieve response information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Release History
+
+## v2.1.8 (2021-xx-xx)
+- Fixed `Get-VCFApplicationVirtualNetwork`cmdlet when passing the ID of the Application Virtual Network the response was failing.
+- Updated `Get-VCFFederation` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
+- Updated `Set-VCFFederation` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
+- Updated `Remove-VCFFederation` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
+- Updated `Get-VCFFederationMember` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
+- Updated `New-VCFFederationInvite` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
+- Updated `Join-VCFFederation` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
+
+
 ## v2.1.7 (2021-30-11)
 - Fixed `New-VCFCluster`cmdlet where incorrect braces prevented the ability to retrieve response information.
 - Added `Get-VCFvRLIConnection` cmdlet to get the connection status of VI Workload Domains to vRealize Log Insight.

--- a/PowerVCF.psm1
+++ b/PowerVCF.psm1
@@ -51,13 +51,13 @@ Function Request-VCFToken {
         It is required once per session before running all other cmdlets
 
         .EXAMPLE
-        PS C:\> Request-VCFToken -fqdn sfo-vcf01.sfo.rainpole.io -username administrator@vsphere.local -password VMw@re1!
+        Request-VCFToken -fqdn sfo-vcf01.sfo.rainpole.io -username administrator@vsphere.local -password VMw@re1!
         This example shows how to connect to SDDC Manager to request API access & refresh tokens
 
         .EXAMPLE
-        PS C:\> Request-VCFToken -fqdn sfo-vcf01.sfo.rainpole.io -username admin@local -password VMw@re1!VMw@re1!
+        Request-VCFToken -fqdn sfo-vcf01.sfo.rainpole.io -username admin@local -password VMw@re1!VMw@re1!
         This example shows how to connect to SDDC Manager using local account admin@local
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$fqdn,
@@ -111,9 +111,9 @@ Function Connect-CloudBuilder {
         in a base64 string. It is required once per session before running all other cmdlets
 
         .EXAMPLE
-        PS C:\> Connect-CloudBuilder -fqdn sfo-cb01.sfo.rainpole.io -username admin -password VMware1!
+        Connect-CloudBuilder -fqdn sfo-cb01.sfo.rainpole.io -username admin -password VMware1!
         This example shows how to connect to the Cloud Builder applaince
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$fqdn,
@@ -157,25 +157,25 @@ Export-ModuleMember -Function Connect-CloudBuilder
 
 Function Get-VCFApplicationVirtualNetwork {
     <#
-          .SYNOPSIS
-          Retrieves all Application Virtual Networks
+        .SYNOPSIS
+        Retrieves all Application Virtual Networks
 
-          .DESCRIPTION
-          The Get-VCFApplicationVirtualNetwork cmdlet retrieves the Application Virtual Networks configured in SDDC Manager
+        .DESCRIPTION
+        The Get-VCFApplicationVirtualNetwork cmdlet retrieves the Application Virtual Networks configured in SDDC Manager
         - regionType supports REGION_A, REGION_B, X_REGION
 
-          .EXAMPLE
-          PS C:\> Get-VCFApplicationVirtualNetwork
-          This example demonstrates how to retrieve a list of Application Virtual Networks
+        .EXAMPLE
+        Get-VCFApplicationVirtualNetwork
+        This example demonstrates how to retrieve a list of Application Virtual Networks
 
-          .EXAMPLE
-          PS C:\> Get-VCFApplicationVirtualNetwork -regionType REGION_A
-          This example demonstrates how to retrieve the details of the regionType REGION_A Application Virtual Networks
+        .EXAMPLE
+        Get-VCFApplicationVirtualNetwork -regionType REGION_A
+        This example demonstrates how to retrieve the details of the regionType REGION_A Application Virtual Networks
 
-          .EXAMPLE
-          PS C:\> Get-VCFApplicationVirtualNetwork -id 577e6262-73a9-4825-bdb9-4341753639ce
-          This example demonstrates how to retrieve the details of the Application Virtual Networks using the id
-  #>
+        .EXAMPLE
+        Get-VCFApplicationVirtualNetwork -id 577e6262-73a9-4825-bdb9-4341753639ce
+        This example demonstrates how to retrieve the details of the Application Virtual Networks using the id
+    #>
 
     Param (
         [Parameter (Mandatory = $false)] [ValidateSet("REGION_A", "REGION_B", "X_REGION")] [ValidateNotNullOrEmpty()] [String]$regionType,
@@ -196,8 +196,7 @@ Function Get-VCFApplicationVirtualNetwork {
             $response
         }
         if ($PsBoundParameters.ContainsKey("id")) {
-            #$uri = "https://$sddcManager/internal/avns/$id"
-            $uri = "https://$sddcManager/inventory/avns/$id"
+            $uri = "https://$sddcManager/v1/avns/avns?id=$id"
             $response = Invoke-RestMethod -Method GET -URI $uri -headers $headers
             $response
         }
@@ -210,20 +209,20 @@ Export-ModuleMember -Function Get-VCFApplicationVirtualNetwork
 
 Function Add-VCFApplicationVirtualNetwork {
     <#
-          .SYNOPSIS
-          Creates Application Virtual Networks
+        .SYNOPSIS
+        Creates Application Virtual Networks
 
-          .DESCRIPTION
-          The Add-VCFApplicationVirtualNetwork cmdlet creates Application Virtual Networks in SDDC Manager and NSX-T Data Center
+        .DESCRIPTION
+        The Add-VCFApplicationVirtualNetwork cmdlet creates Application Virtual Networks in SDDC Manager and NSX-T Data Center
 
-          .EXAMPLE
-          PS C:\> Add-VCFApplicationVirtualNetwork -json (Get-Content -Raw .\SampleJSON\Application Virtual Network\avnOPverlaySpec.json)
-          This example demonstrates how to deploy the Application Virtual Networks using the JSON spec supplied
+        .EXAMPLE
+        Add-VCFApplicationVirtualNetwork -json (Get-Content -Raw .\SampleJSON\Application Virtual Network\avnOPverlaySpec.json)
+        This example demonstrates how to deploy the Application Virtual Networks using the JSON spec supplied
 
-          .EXAMPLE
-          PS C:\> Add-VCFApplicationVirtualNetwork -json (Get-Content -Raw .\SampleJSON\Application Virtual Network\avnOverlaySpec.json) -validate
-          This example demonstrates how to validate the Application Virtual Networks JSON spec supplied
-  #>
+        .EXAMPLE
+        Add-VCFApplicationVirtualNetwork -json (Get-Content -Raw .\SampleJSON\Application Virtual Network\avnOverlaySpec.json) -validate
+        This example demonstrates how to validate the Application Virtual Networks JSON spec supplied
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$json,
@@ -258,20 +257,20 @@ Export-ModuleMember -Function Add-VCFApplicationVirtualNetwork
 
 Function Get-VCFBackupConfiguration {
     <#
-      .SYNOPSIS
-      Gets the backup configuration of NSX Manager and SDDC Manager
+        .SYNOPSIS
+        Gets the backup configuration of NSX Manager and SDDC Manager
 
-      .DESCRIPTION
-      The Get-VCFBackupConfiguration cmdlet retrieves the current backup configuration details
+        .DESCRIPTION
+        The Get-VCFBackupConfiguration cmdlet retrieves the current backup configuration details
 
-      .EXAMPLE
-      PS C:\> Get-VCFBackupConfiguration
-      This example retrieves the backup configuration
+        .EXAMPLE
+        Get-VCFBackupConfiguration
+        This example retrieves the backup configuration
 
-      .EXAMPLE
-      PS C:\> Get-VCFBackupConfiguration | ConvertTo-Json
-      This example retrieves the backup configuration and outputs it in json format
-  #>
+        .EXAMPLE
+        Get-VCFBackupConfiguration | ConvertTo-Json
+        This example retrieves the backup configuration and outputs it in json format
+    #>
 
     Try {
         createHeader # Calls createHeader function to set Accept & Authorization
@@ -288,17 +287,17 @@ Export-ModuleMember -Function Get-VCFBackupConfiguration
 
 Function Set-VCFBackupConfiguration {
     <#
-      .SYNOPSIS
-      Configure backup settings for NSX and SDDC manager
+        .SYNOPSIS
+        Configure backup settings for NSX and SDDC manager
 
-      .DESCRIPTION
-      The Set-VCFBackupConfiguration cmdlet configures or updates the backup configuration details for
-      backing up NSX and SDDC Manager
+        .DESCRIPTION
+        The Set-VCFBackupConfiguration cmdlet configures or updates the backup configuration details for
+        backing up NSX and SDDC Manager
 
-      .EXAMPLE
-      PS C:\> Set-VCFBackupConfiguration -json (Get-Content -Raw .\SampleJSON\Backup\backupConfiguration.json)
-      This example shows how to update the backup configuration
-  #>
+        .EXAMPLE
+        Set-VCFBackupConfiguration -json (Get-Content -Raw .\SampleJSON\Backup\backupConfiguration.json)
+        This example shows how to update the backup configuration
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$json
@@ -327,9 +326,9 @@ Function Start-VCFBackup {
         The Start-VCFBackup cmdlet invokes the SDDC Manager backup task
 
         .EXAMPLE
-        PS C:\> Start-VCFBackup
+        Start-VCFBackup
         This example shows how to start the SDDC Manager backup
-      #>
+    #>
 
     Try {
         createHeader # Calls createHeader function to set Accept & Authorization
@@ -355,9 +354,9 @@ Function Start-VCFRestore {
         The Start-VCFRestore cmdlet invokes the SDDC Manager restore task
 
         .EXAMPLE
-        PS C:\> Start-VCFRestore -backupFile "/tmp/vcf-backup-sfo-vcf01-sfo-rainpole-io-2020-04-20-14-37-25.tar.gz" -passphrase "VMw@re1!VMw@re1!"
+        Start-VCFRestore -backupFile "/tmp/vcf-backup-sfo-vcf01-sfo-rainpole-io-2020-04-20-14-37-25.tar.gz" -passphrase "VMw@re1!VMw@re1!"
         This example shows how to start the SDDC Manager restore
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$backupFile,
@@ -386,9 +385,9 @@ Function Get-VCFRestoreTask {
         The Get-VCFRestoreTask cmdlet retrieves the status of the restore task
 
         .EXAMPLE
-        PS C:\> Get-VCFRestoreTask -id a5788c2d-3126-4c8f-bedf-c6b812c4a753
+        Get-VCFRestoreTask -id a5788c2d-3126-4c8f-bedf-c6b812c4a753
         This example shows how to retrieve the status of the restore task by id
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$id
@@ -424,19 +423,19 @@ Function Get-VCFBundle {
         i.e. Manually uploaded bundles and bundles available via depot access.
 
         .EXAMPLE
-        PS C:\> Get-VCFBundle
+        Get-VCFBundle
         This example gets the list of bundles and all their details
 
         .EXAMPLE
-        PS C:\> Get-VCFBundle | Select version,downloadStatus,id
+        Get-VCFBundle | Select version,downloadStatus,id
         This example gets the list of bundles and filters on the version, download status and the id only
 
         .EXAMPLE
-        PS C:\> Get-VCFBundle -id 7ef354ab-13a6-4e39-9561-10d2c4de89db
+        Get-VCFBundle -id 7ef354ab-13a6-4e39-9561-10d2c4de89db
         This example gets the details of a specific bundle by its id
 
         .EXAMPLE
-        PS C:\> Get-VCFBundle | Where {$_.description -Match "vRealize"}
+        Get-VCFBundle | Where {$_.description -Match "vRealize"}
         This example lists all bundles that match vRealize in the description field
     #>
 
@@ -474,7 +473,7 @@ Function Request-VCFBundle {
         Only one download can be triggered for a bundle.
 
         .EXAMPLE
-        PS C:\> Request-VCFBundle -id 7ef354ab-13a6-4e39-9561-10d2c4de89db
+        Request-VCFBundle -id 7ef354ab-13a6-4e39-9561-10d2c4de89db
         This example requests the immediate download of a bundle based on its id
     #>
 
@@ -506,11 +505,11 @@ Function Start-VCFBundleUpload {
         Prerequisite: The bundle should have been downloaded to SDDC Manager VM using the bundle transfer utility tool
 
         .EXAMPLE
-        PS C:\> Start-VCFBundleUpload -json $jsonSpec
+        Start-VCFBundleUpload -json $jsonSpec
         This example invokes the upload of a bundle onto SDDC Manager using a variable
 
-               .EXAMPLE
-        PS C:\> Start-VCFBundleUpload -json (Get-Content -Raw .\upgradeDomain.json)
+        .EXAMPLE
+        Start-VCFBundleUpload -json (Get-Content -Raw .\upgradeDomain.json)
         This example invokes the upload of a bundle onto SDDC Manager by passing a JSON file
     #>
 
@@ -546,9 +545,9 @@ Function Get-VCFCeip {
         The Get-VCFCeip cmdlet retrieves the current setting for Customer Experience Improvement Program (CEIP) of the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFCeip
+        Get-VCFCeip
         This example shows how to get the current setting of CEIP
-      #>
+    #>
 
     Try {
         createHeader # Calls createHeader function to set Accept & Authorization
@@ -573,13 +572,13 @@ Function Set-VCFCeip {
         SDDC Manager and the components managed (vCenter Server, vSAN and NSX Manager)
 
         .EXAMPLE
-        PS C:\> Set-VCFCeip -ceipSetting DISABLE
+        Set-VCFCeip -ceipSetting DISABLE
         This example shows how to DISABLE CEIP for SDDC Manager, vCenter Server, vSAN and NSX Manager
 
         .EXAMPLE
-        PS C:\> Set-VCFCeip -ceipSetting ENABLE
+        Set-VCFCeip -ceipSetting ENABLE
         This example shows how to ENABLE CEIP for SDDC Manager, vCenter Server, vSAN and NSX Manager
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateSet("ENABLE", "DISABLE")] [String]$ceipSetting
@@ -614,19 +613,19 @@ Function Get-VCFCertificateAuthority {
         The Get-VCFCertificateAuthority cmdlet retrieves the certificate authorities information for the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFCertificateAuthority
+        Get-VCFCertificateAuthority
         This example shows how to get the certificate authority configuration from the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFCertificateAuthority | ConvertTo-Json
+        Get-VCFCertificateAuthority | ConvertTo-Json
         This example shows how to get the certificate authority configuration from the connected SDDC Manager
         and output to Json format
 
         .EXAMPLE
-        PS C:\> Get-VCFCertificateAuthority -caType Microsoft
+        Get-VCFCertificateAuthority -caType Microsoft
         This example shows how to get the certificate authority configuration for a Microsoft Certificate Authority from the
         connected SDDC Manager
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $false)] [ValidateSet("OpenSSL", "Microsoft")] [String] $caType
@@ -661,9 +660,9 @@ Function Remove-VCFCertificateAuthority {
         The Remove-VCFCertificateAuthority cmdlet removes the certificate authority configuration from the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Remove-VCFCertificateAuthority
+        Remove-VCFCertificateAuthority
         This example removes the Micosoft certificate authority configuration from the connected SDDC Manager
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateSet("OpenSSL", "Microsoft")] [String] $caType
@@ -691,9 +690,9 @@ Function Set-VCFMicrosoftCA {
         Configures the Microsoft Certificate Authorty on the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Set-VCFMicrosoftCA -serverUrl "https://rpl-dc01.rainpole.io/certsrv" -username Administrator -password "VMw@re1!" -templateName VMware
+        Set-VCFMicrosoftCA -serverUrl "https://rpl-dc01.rainpole.io/certsrv" -username Administrator -password "VMw@re1!" -templateName VMware
         This example shows how to configure a Microsoft certificate authority on the connected SDDC Manager
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$serverUrl,
@@ -724,9 +723,9 @@ Function Set-VCFOpenSSLCA {
         Configures the OpenSSL Certificate Authorty on the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Set-VCFOpenSSLCA -commonName sddcManager -organization Rainpole -organizationUnit Support -locality "Palo Alto" -state CA -country US
+        Set-VCFOpenSSLCA -commonName sddcManager -organization Rainpole -organizationUnit Support -locality "Palo Alto" -state CA -country US
         This example shows how to configure a Microsoft certificate authority on the connected SDDC Manager
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$commonName,
@@ -759,13 +758,13 @@ Function Get-VCFCertificateCSR {
         The Get-VCFCertificateCSR cmdlet gets the available CSRs that have been created on SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFCertificateCSRs -domainName MGMT
+        Get-VCFCertificateCSRs -domainName MGMT
         This example gets a list of CSRs and displays the output
 
         .EXAMPLE
-        PS C:\> Get-VCFCertificateCSRs -domainName MGMT | ConvertTo-Json
+        Get-VCFCertificateCSRs -domainName MGMT | ConvertTo-Json
         This example gets a list of CSRs and displays them in JSON format
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$domainName
@@ -792,13 +791,13 @@ Function Request-VCFCertificateCSR {
         .DESCRIPTION
         The Request-VCFCertificateCSR generates CSR(s) for the selected resource(s) in the domain
         - Resource Types (SDDC_MANAGER, PSC, VCENTER, NSX_MANAGER, NSXT_MANAGER, VRA,
-          VRLI, VROPS, VRSLCM, VXRAIL_MANAGER
+        VRLI, VROPS, VRSLCM, VXRAIL_MANAGER
 
         .EXAMPLE
-        PS C:\> Request-VCFCertificateCSR -domainName MGMT -json .\requestCsrSpec.json
+        Request-VCFCertificateCSR -domainName MGMT -json .\requestCsrSpec.json
         This example requests the generation of the CSR based on the entries within the requestCsrSpec.json file for resources within
-          the domain called MGMT
-      #>
+        the domain called MGMT
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$json,
@@ -833,21 +832,21 @@ Function Get-VCFCertificate {
         The Get-VCFCertificate cmdlet gets the latest generated certificate(s) in a domain
 
         .EXAMPLE
-        PS C:\> Get-VCFCertificate -domainName sfo-m01
+        Get-VCFCertificate -domainName sfo-m01
         This example gets a list of certificates that have been generated
 
         .EXAMPLE
-        PS C:\> Get-VCFCertificate -domainName sfo-m01 | ConvertTo-Json
+        Get-VCFCertificate -domainName sfo-m01 | ConvertTo-Json
         This example gets a list of certificates and displays them in JSON format
 
         .EXAMPLE
-        PS C:\> Get-VCFCertificate -domainName sfo-m01 | Select issuedTo
+        Get-VCFCertificate -domainName sfo-m01 | Select issuedTo
         This example gets a list of endpoint names where certificates have been issued
 
         .EXAMPLE
-        PS C:\> Get-VCFCertificate -domainName sfo-m01 -resources
+        Get-VCFCertificate -domainName sfo-m01 -resources
         This example gets the certificates of all resources in the domain
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$domainName,
@@ -883,13 +882,13 @@ Function Request-VCFCertificate {
         The Request-VCFCertificate cmdlet generates certificate(s) for the selected resource(s) in a domain.
         CA must be configured and CSR must be generated beforehand
         - Resource Types (SDDC_MANAGER, PSC, VCENTER, NSX_MANAGER, NSXT_MANAGER, VRA, VRLI, VROPS,
-          VRSLCM, VXRAIL_MANAGER
+        VRSLCM, VXRAIL_MANAGER
 
         .EXAMPLE
-        PS C:\> Request-VCFCertificate -domainName MGMT -json .\requestCertificateSpec.json
+        Request-VCFCertificate -domainName MGMT -json .\requestCertificateSpec.json
         This example requests the generation of the Certificates based on the entries within the requestCertificateSpec.json file
         for resources within the domain called MGMT
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$json,
@@ -925,10 +924,10 @@ Function Set-VCFCertificate {
         The Set-VCFCertificate cmdlet replaces certificate(s) for the selected resource(s) in a domain
 
         .EXAMPLE
-        PS C:\> Set-VCFCertificate -domainName MGMT -json .\updateCertificateSpec.json
+        Set-VCFCertificate -domainName MGMT -json .\updateCertificateSpec.json
         This example replaces the Certificates based on the entries within the requestCertificateSpec.json file
         for resources within the domain called MGMT
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$json,
@@ -969,17 +968,17 @@ Function Get-VCFCluster {
         The Get-VCFCluster cmdlet connects to the specified SDDC Manager & retrieves a list of clusters.
 
         .EXAMPLE
-        PS C:\> Get-VCFCluster
+        Get-VCFCluster
         This example shows how to get a list of all clusters
 
         .EXAMPLE
-        PS C:\> Get-VCFCluster -name wld01-cl01
+        Get-VCFCluster -name wld01-cl01
         This example shows how to get a cluster by name
 
         .EXAMPLE
-        PS C:\> Get-VCFCluster -id 8423f92e-e4b9-46e7-92f7-befce4755ba2
+        Get-VCFCluster -id 8423f92e-e4b9-46e7-92f7-befce4755ba2
         This example shows how to get a cluster by id
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$name,
@@ -1020,9 +1019,9 @@ Function New-VCFCluster {
         The New-VCFCluster cmdlet connects to the specified SDDC Manager and creates a cluster in a specified workload domains
 
         .EXAMPLE
-        PS C:\> New-VCFCluster -json .\WorkloadDomain\addClusterSpec.json
+        New-VCFCluster -json .\WorkloadDomain\addClusterSpec.json
         This example shows how to create a cluster in a Workload Domain from a json spec
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$json
@@ -1068,17 +1067,17 @@ Function Set-VCFCluster {
         removing a host(s). A cluster can also be marked for deletion
 
         .EXAMPLE
-        PS C:\> Set-VCFCluster -id a511b625-8eb8-417e-85f0-5b47ebb4c0f1 -json .\Cluster\clusterExpansionSpec.json
+        Set-VCFCluster -id a511b625-8eb8-417e-85f0-5b47ebb4c0f1 -json .\Cluster\clusterExpansionSpec.json
         This example shows how to expand a cluster by adding a host(s)
 
         .EXAMPLE
-        PS C:\> Set-VCFCluster -id a511b625-8eb8-417e-85f0-5b47ebb4c0f1 -json .\Cluster\clusterCompactionSpec.json
+        Set-VCFCluster -id a511b625-8eb8-417e-85f0-5b47ebb4c0f1 -json .\Cluster\clusterCompactionSpec.json
         This example shows how to compact a cluster by removing a host(s)
 
         .EXAMPLE
-        PS C:\> Set-VCFCluster -id a511b625-8eb8-417e-85f0-5b47ebb4c0f1 -markForDeletion
+        Set-VCFCluster -id a511b625-8eb8-417e-85f0-5b47ebb4c0f1 -markForDeletion
         This example shows how to mark a cluster for deletion
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$id,
@@ -1136,9 +1135,9 @@ Function Remove-VCFCluster {
         The Remove-VCFCluster cmdlet connects to the specified SDDC Manager & deletes a cluster.
 
         .EXAMPLE
-        PS C:\> Remove-VCFCluster -id a511b625-8eb8-417e-85f0-5b47ebb4c0f1
+        Remove-VCFCluster -id a511b625-8eb8-417e-85f0-5b47ebb4c0f1
         This example shows how to delete a cluster
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$id
@@ -1166,9 +1165,9 @@ Function Get-VCFClusterValidation {
         The Get-VCFClusterValidation cmdlet returns the status of a validation of the json
 
         .EXAMPLE
-        PS C:\> Get-VCFClusterValidation -id 001235d8-3e40-4a5a-8a89-09985dac1434
+        Get-VCFClusterValidation -id 001235d8-3e40-4a5a-8a89-09985dac1434
         This example shows how to get the cluster validation task based on the id
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$id
@@ -1206,21 +1205,21 @@ Function Get-VCFCredential {
         Authenticated user must have ADMIN role.
 
         .EXAMPLE
-        PS C:\> Get-VCFCredential
+        Get-VCFCredential
         This example shows how to get a list of credentials
 
         .EXAMPLE
-        PS C:\> Get-VCFCredential -resourceType VCENTER
+        Get-VCFCredential -resourceType VCENTER
         This example shows how to get a list of VCENTER credentials
 
         .EXAMPLE
-        PS C:\> Get-VCFCredential -resourceName sfo01-m01-esx01.sfo.rainpole.io
+        Get-VCFCredential -resourceName sfo01-m01-esx01.sfo.rainpole.io
         This example shows how to get the credential for a specific resourceName (FQDN)
 
         .EXAMPLE
-        PS C:\> Get-VCFCredential -id 3c4acbd6-34e5-4281-ad19-a49cb7a5a275
+        Get-VCFCredential -id 3c4acbd6-34e5-4281-ad19-a49cb7a5a275
         This example shows how to get the credential using the id
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$resourceName,
@@ -1269,9 +1268,9 @@ Function Set-VCFCredential {
         Credentials can be updated with a specified password(s) or rotated using system generated password(s).
 
         .EXAMPLE
-        PS C:\> Set-VCFCredential -json .\Credential\updateCredentialSpec.json
+        Set-VCFCredential -json .\Credential\updateCredentialSpec.json
         This example shows how to update a credential using a json spec
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$json
@@ -1308,17 +1307,17 @@ Function Get-VCFCredentialTask {
         credential tasks in reverse chronological order.
 
         .EXAMPLE
-        PS C:\> Get-VCFCredentialTask
+        Get-VCFCredentialTask
         This example shows how to get a list of all credentials tasks
 
         .EXAMPLE
-        PS C:\> Get-VCFCredentialTask -id 7534d35d-98fb-43de-bcf7-2776beb6fcc3
+        Get-VCFCredentialTask -id 7534d35d-98fb-43de-bcf7-2776beb6fcc3
         This example shows how to get the credential tasks for a specific task id
 
         .EXAMPLE
-        PS C:\> Get-VCFCredentialTask -id 7534d35d-98fb-43de-bcf7-2776beb6fcc3 -resourceCredentials
+        Get-VCFCredentialTask -id 7534d35d-98fb-43de-bcf7-2776beb6fcc3 -resourceCredentials
         This example shows how to get resource credentials (for e.g. ESXI) for a credential task id
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$id,
@@ -1359,9 +1358,9 @@ Function Stop-VCFCredentialTask {
         The Stop-VCFCredentialTask cmdlet connects to the specified SDDC Manager and cancles a failed update or rotate passwords task.
 
         .EXAMPLE
-        PS C:\> Stop-VCFCredentialTask -id 4d661acc-2be6-491d-9256-ba3c78020e5d
+        Stop-VCFCredentialTask -id 4d661acc-2be6-491d-9256-ba3c78020e5d
         This example shows how to cancel a failed rotate or update password task.
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$id
@@ -1394,9 +1393,9 @@ Function Restart-VCFCredentialTask {
         The Restart-VCFCredentialTask cmdlet connects to the specified SDDC Manager and retry a failed rotate/update password task
 
         .EXAMPLE
-        PS C:\> Restart-VCFCredentialTask -id 4d661acc-2be6-491d-9256-ba3c78020e5d -json .\Credential\updateCredentialSpec.json
+        Restart-VCFCredentialTask -id 4d661acc-2be6-491d-9256-ba3c78020e5d -json .\Credential\updateCredentialSpec.json
         This example shows how to update passwords of a resource type using a json spec
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$id,
@@ -1444,9 +1443,9 @@ Function Get-VCFDepotCredential {
         Retrieves the configuration for the depot of the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFDepotCredential
+        Get-VCFDepotCredential
         This example shows credentials that have been configured for the depot.
-      #>
+    #>
 
     Try {
         createHeader # Calls createHeader function to set Accept & Authorization
@@ -1470,9 +1469,9 @@ Function Set-VCFDepotCredential {
         Update the configuration for the depot of the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Set-VCFDepotCredential -username "user@yourdomain.com" -password "VMware1!"
+        Set-VCFDepotCredential -username "user@yourdomain.com" -password "VMware1!"
         This example sets the credentials that have been configured for the depot.
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$username,
@@ -1504,28 +1503,28 @@ Export-ModuleMember -Function Set-VCFDepotCredential
 
 Function Get-VCFWorkloadDomain {
     <#
-           .SYNOPSIS
+        .SYNOPSIS
         Connects to the specified SDDC Manager & retrieves a list of workload domains.
 
         .DESCRIPTION
         The Get-VCFWorkloadDomain cmdlet connects to the specified SDDC Manager & retrieves a list of workload domains.
 
         .EXAMPLE
-        PS C:\> Get-VCFWorkloadDomain
+        Get-VCFWorkloadDomain
         This example shows how to get a list of Workload Domains
 
         .EXAMPLE
-        PS C:\> Get-VCFWorkloadDomain -name WLD01
+        Get-VCFWorkloadDomain -name WLD01
         This example shows how to get a Workload Domain by name
 
         .EXAMPLE
-        PS C:\> Get-VCFWorkloadDomain -id 8423f92e-e4b9-46e7-92f7-befce4755ba2
+        Get-VCFWorkloadDomain -id 8423f92e-e4b9-46e7-92f7-befce4755ba2
         This example shows how to get a Workload Domain by id
 
         .EXAMPLE
-        PS C:\> Get-VCFWorkloadDomain -id 8423f92e-e4b9-46e7-92f7-befce4755ba2 -endpoints | ConvertTo-Json
+        Get-VCFWorkloadDomain -id 8423f92e-e4b9-46e7-92f7-befce4755ba2 -endpoints | ConvertTo-Json
         This example shows how to get endpoints of a Workload Domain by its id and displays the output in Json format
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$name,
@@ -1572,9 +1571,9 @@ Function New-VCFWorkloadDomain {
         The New-VCFWorkloadDomain cmdlet connects to the specified SDDC Manager & creates a workload domain.
 
         .EXAMPLE
-        PS C:\> New-VCFWorkloadDomain -json .\WorkloadDomain\workloadDomainSpec.json
+        New-VCFWorkloadDomain -json .\WorkloadDomain\workloadDomainSpec.json
         This example shows how to create a Workload Domain from a json spec
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$json
@@ -1614,9 +1613,9 @@ Function Set-VCFWorkloadDomain {
         The Set-VCFWorkloadDomain cmdlet connects to the specified SDDC Manager & marks a workload domain for deletion.
 
         .EXAMPLE
-        PS C:\> Set-VCFWorkloadDomain -id fbdcf199-c086-43aa-9071-5d53b5c5b99d
+        Set-VCFWorkloadDomain -id fbdcf199-c086-43aa-9071-5d53b5c5b99d
         This example shows how to mark a workload domain for deletion
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$id
@@ -1644,10 +1643,10 @@ Function Remove-VCFWorkloadDomain {
         Before a workload domain can be deleted it must first be marked for deletion. See Set-VCFWorkloadDomain
         The Remove-VCFWorkloadDomain cmdlet connects to the specified SDDC Manager & deletes a workload domain.
 
-           .EXAMPLE
-        PS C:\> Remove-VCFWorkloadDomain -id fbdcf199-c086-43aa-9071-5d53b5c5b99d
+        .EXAMPLE
+        Remove-VCFWorkloadDomain -id fbdcf199-c086-43aa-9071-5d53b5c5b99d
         This example shows how to delete a workload domain
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$id
@@ -1681,20 +1680,26 @@ Function Get-VCFFederation {
         The Get-VCFFederation cmdlet gets the complete information about the existing VCF Federation
 
         .EXAMPLE
-        PS C:\> Get-VCFFederation
+        Get-VCFFederation
         This example list all details concerning the VCF Federation
 
         .EXAMPLE
-        PS C:\> Get-VCFFederation | ConvertTo-Json
+        Get-VCFFederation | ConvertTo-Json
         This example list all details concerning the VCF Federation and outputs them in Json format
-      #>
+    #>
 
     Try {
-        createHeader # Calls createHeader function to set Accept & Authorization
-        checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
-        $uri = "https://$sddcManager/v1/sddc-federation"
-        $response = Invoke-RestMethod -Method GET -URI $uri -headers $headers
-        $response
+        $vcfVersion = ((Get-VCFManager).version -Split ('\.\d{1}\-\d{8}')) -split '\s+' -match '\S'
+        if ($vcfVersion -lt "4.4.0") {
+            createHeader # Calls createHeader function to set Accept & Authorization
+            checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
+            $uri = "https://$sddcManager/v1/sddc-federation"
+            $response = Invoke-RestMethod -Method GET -URI $uri -headers $headers
+            $response
+        }
+        else {
+            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
+        }
     }
     Catch {
         ResponseException -object $_
@@ -1711,24 +1716,30 @@ Function Set-VCFFederation {
         The Set-VCFFederation cmdlet bootstraps the creation of a Federation in VCF
 
         .EXAMPLE
-        PS C:\> Set-VCFFederation -json $jsonSpec
+        Set-VCFFederation -json $jsonSpec
         This example shows how to create a fedration using the using a variable
 
         .EXAMPLE
-        PS C:\> Set-VCFFederation -json (Get-Content -Raw .\federationSpec.json)
+        Set-VCFFederation -json (Get-Content -Raw .\federationSpec.json)
         This example shows how to create a fedration using the using a JSON file
-      #>
+    #>
 
     Param (
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$json
     )
 
     Try {
-        createHeader # Calls createHeader function to set Accept & Authorization
-        checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
-        $uri = "https://$sddcManager/v1/sddc-federation"
-        $response = Invoke-RestMethod -Method PUT -URI $uri -headers $headers -ContentType application/json -body $json
-        $response
+        $vcfVersion = ((Get-VCFManager).version -Split ('\.\d{1}\-\d{8}')) -split '\s+' -match '\S'
+        if ($vcfVersion -lt "4.4.0") {
+            createHeader # Calls createHeader function to set Accept & Authorization
+            checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
+            $uri = "https://$sddcManager/v1/sddc-federation"
+            $response = Invoke-RestMethod -Method PUT -URI $uri -headers $headers -ContentType application/json -body $json
+            $response
+        }
+        else {
+            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
+        }
     }
     Catch {
         ResponseException -object $_
@@ -1745,32 +1756,39 @@ Function Remove-VCFFederation {
         A function that ensures VCF Federation is empty and completely dismantles it.
 
         .EXAMPLE
-        PS C:\> Remove-VCFFederation
+        Remove-VCFFederation
         This example demonstrates how to dismantle the VCF Federation
-      #>
+    #>
 
-    createHeader # Calls createHeader function to set Accept & Authorization
-    checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
-    $uri = "https://$sddcManager/v1/sddc-federation"
+    
     Try {
-        # Verify that SDDC Manager we're connected to is a controller and only one in the Federation
-        $sddcs = Get-VCFFederation | Select-Object memberDetails
-        Foreach ($sddc in $sddcs) {
-            if ($sddc.memberDetails.role -eq "CONTROLLER") {
-                $controller++
-                if ($sddc.memberDetails.role -eq "MEMBER") {
-                    $member++
+        $vcfVersion = ((Get-VCFManager).version -Split ('\.\d{1}\-\d{8}')) -split '\s+' -match '\S'
+        if ($vcfVersion -lt "4.4.0") {
+            createHeader # Calls createHeader function to set Accept & Authorization
+            checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
+            $uri = "https://$sddcManager/v1/sddc-federation"
+            # Verify that SDDC Manager we're connected to is a controller and only one in the Federation
+            $sddcs = Get-VCFFederation | Select-Object memberDetails
+            Foreach ($sddc in $sddcs) {
+                if ($sddc.memberDetails.role -eq "CONTROLLER") {
+                    $controller++
+                    if ($sddc.memberDetails.role -eq "MEMBER") {
+                        $member++
+                    }
                 }
             }
+            if ($controller -gt 1) {
+                Throw "Only one controller can be present when dismantling VCF Federation. Remove additional controllers and try again"
+            }
+            if ($member -gt 0) {
+                Throw "VCF Federation members still exist. Remove all members and additional controllers before dismantling VCF Federation"
+            }
+            $response = Invoke-RestMethod -Method DELETE -URI $uri -headers $headers
+            $response
         }
-        if ($controller -gt 1) {
-            Throw "Only one controller can be present when dismantling VCF Federation. Remove additional controllers and try again"
+        else {
+            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
-        if ($member -gt 0) {
-            Throw "VCF Federation members still exist. Remove all members and additional controllers before dismantling VCF Federation"
-        }
-        $response = Invoke-RestMethod -Method DELETE -URI $uri -headers $headers
-        $response
     }
     Catch {
         ResponseException -object $_
@@ -1797,19 +1815,19 @@ Function Get-VCFHost {
         - UNASSIGNED_UNUSEABLE - Hosts that are currently not assigned to any domain and can be used for other domain tasks after completion of cleanup operation
 
         .EXAMPLE
-        PS C:\> Get-VCFHost
+        Get-VCFHost
         This example shows how to get all hosts regardless of status
 
         .EXAMPLE
-        PS C:\> Get-VCFHost -Status ASSIGNED
+        Get-VCFHost -Status ASSIGNED
         This example shows how to get all hosts with a specific status
 
         .EXAMPLE
-        PS C:\> Get-VCFHost -id edc4f372-aab5-4906-b6d8-9b96d3113304
+        Get-VCFHost -id edc4f372-aab5-4906-b6d8-9b96d3113304
         This example shows how to get a host by id
 
         .EXAMPLE
-        PS C:\> Get-VCFHost -fqdn sfo01-m01-esx01.sfo.rainpole.io
+        Get-VCFHost -fqdn sfo01-m01-esx01.sfo.rainpole.io
         This example shows how to get a host by fqdn
     #>
 
@@ -1870,11 +1888,11 @@ Function New-VCFCommissionedHost {
         Host list spec is provided in a JSON file.
 
         .EXAMPLE
-        PS C:\> New-VCFCommissionedHost -json .\Host\commissionHosts\commissionHostSpec.json
+        New-VCFCommissionedHost -json .\Host\commissionHosts\commissionHostSpec.json
         This example shows how to commission a list of hosts based on the details provided in the JSON file
 
         .EXAMPLE
-        PS C:\> New-VCFCommissionedHost -json .\Host\commissionHosts\commissionHostSpec.json -validate
+        New-VCFCommissionedHost -json .\Host\commissionHosts\commissionHostSpec.json -validate
         This example shows how to validate the JSON spec before starting the workflow
     #>
 
@@ -1943,7 +1961,7 @@ Function Remove-VCFCommissionedHost {
         The Remove-VCFCommissionedHost cmdlet connects to the specified SDDC Manager and decommissions a list of hosts.
 
         .EXAMPLE
-        PS C:\> Remove-VCFCommissionedHost -json .\Host\decommissionHostSpec.json
+        Remove-VCFCommissionedHost -json .\Host\decommissionHostSpec.json
         This example shows how to decommission a set of hosts based on the details provided in the JSON file.
     #>
 
@@ -1989,20 +2007,20 @@ Function Get-VCFLicenseKey {
         The Get-VCFLicenseKey cmdlet connects to the specified SDDC Manager and retrieves a list of License keys
 
         .EXAMPLE
-        PS C:\> Get-VCFLicenseKey
+        Get-VCFLicenseKey
         This example shows how to get a list of all License keys
 
         .EXAMPLE
-        PS C:\> Get-VCFLicenseKey -key "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA"
+        Get-VCFLicenseKey -key "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA"
         This example shows how to get a specified License key
 
         .EXAMPLE
-        PS C:\> Get-VCFLicenseKey -productType VCENTER
+        Get-VCFLicenseKey -productType VCENTER
         This example shows how to get a License Key by product type
         Supported Product Types: SDDC_MANAGER, VCENTER, VSAN, ESXI, NSXT
 
         .EXAMPLE
-        PS C:\> Get-VCFLicenseKey -status EXPIRED
+        Get-VCFLicenseKey -status EXPIRED
         This example shows how to get a License by status
         Supported Status Types: EXPIRED, ACTIVE, NEVER_EXPIRES
     #>
@@ -2052,7 +2070,7 @@ Function New-VCFLicenseKey {
         The New-VCFLicenseKey cmdlet connects to the specified SDDC Manager and adds a new License Key.
 
         .EXAMPLE
-        PS C:\> New-VCFLicenseKey -key "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA" -productType VCENTER -description "vCenter License"
+        New-VCFLicenseKey -key "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA" -productType VCENTER -description "vCenter License"
         This example shows how to add a new License key to SDDC Manager
     #>
 
@@ -2086,7 +2104,7 @@ Function Remove-VCFLicenseKey {
         A license Key can only be removed if it is not in use.
 
         .EXAMPLE
-        PS C:\> Remove-VCFLicenseKey -key "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA"
+        Remove-VCFLicenseKey -key "AAAAA-AAAAA-AAAAA-AAAAA-AAAAA"
         This example shows how to delete a License Key
     #>
 
@@ -2121,20 +2139,26 @@ Function Get-VCFFederationMember {
         Gets the complete information about the existing VCF Federation members.
 
         .EXAMPLE
-        PS C:\> Get-VCFFederationMember
+        Get-VCFFederationMember
         This example lists all details concerning the VCF Federation members.
     #>
-
-    createHeader # Calls createHeader function to set Accept & Authorization
-    checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
-    $uri = "https://$sddcManager/v1/sddc-federation/members"
+    
     Try {
-        $response = Invoke-RestMethod -Method GET -URI $uri -headers $headers
-        if (!$response.federationName) {
-            Throw "Failed to get members, no Federation found."
+        $vcfVersion = ((Get-VCFManager).version -Split ('\.\d{1}\-\d{8}')) -split '\s+' -match '\S'
+        if ($vcfVersion -lt "4.4.0") {
+            createHeader # Calls createHeader function to set Accept & Authorization
+            checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
+            $uri = "https://$sddcManager/v1/sddc-federation/members"
+            $response = Invoke-RestMethod -Method GET -URI $uri -headers $headers
+            if (!$response.federationName) {
+                Throw "Failed to get members, no Federation found."
+            }
+            else {
+                $response.memberDetail
+            }
         }
         else {
-            $response.memberDetail
+            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
     }
     Catch {
@@ -2152,7 +2176,7 @@ Function New-VCFFederationInvite {
         The New-VCFFederationInvite cmdlet creates a new invitation for a member to join the existing VCF Federation.
 
         .EXAMPLE
-        PS C:\> New-VCFFederationInvite -inviteeFqdn lax-vcf01.lax.rainpole.io -inviteeRole MEMBER
+        New-VCFFederationInvite -inviteeFqdn lax-vcf01.lax.rainpole.io -inviteeRole MEMBER
         This example demonstrates how to create an invitation for a specified VCF Manager from the Federation controller.
     #>
 
@@ -2161,23 +2185,29 @@ Function New-VCFFederationInvite {
         [Parameter (Mandatory = $true)] [ValidateSet("MEMBER", "CONTROLLER")] [String]$inviteeRole
     )
 
-    createHeader # Calls createHeader function to set Accept & Authorization
-    checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
-    $uri = "https://$sddcManager/v1/sddc-federation/membership-tokens"
     Try {
-        $sddcMemberRole = Get-VCFFederationMember
-        if ($sddcMemberRole.memberDetail.role -ne "CONTROLLER" -and $sddcMemberRole.memberDetail.fqdn -ne $sddcManager) {
-            Throw "$sddcManager is not the Federation controller. Invitatons to join Federation can only be sent from the Federation controller."
+        $vcfVersion = ((Get-VCFManager).version -Split ('\.\d{1}\-\d{8}')) -split '\s+' -match '\S'
+        if ($vcfVersion -lt "4.4.0") {
+            createHeader # Calls createHeader function to set Accept & Authorization
+            checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
+            $uri = "https://$sddcManager/v1/sddc-federation/membership-tokens"
+            $sddcMemberRole = Get-VCFFederationMember
+            if ($sddcMemberRole.memberDetail.role -ne "CONTROLLER" -and $sddcMemberRole.memberDetail.fqdn -ne $sddcManager) {
+                Throw "$sddcManager is not the Federation controller. Invitatons to join Federation can only be sent from the Federation controller."
+            }
+            else {
+                $inviteeDetails = @{
+                    inviteeRole = $inviteeRole
+                    inviteeFqdn = $inviteeFqdn
+
+                }
+                $ConfigJson = $inviteeDetails | ConvertTo-Json
+                $response = Invoke-RestMethod -Method POST -URI $uri -headers $headers -body $ConfigJson -ContentType 'application/json'
+                $response
+            }
         }
         else {
-            $inviteeDetails = @{
-                inviteeRole = $inviteeRole
-                inviteeFqdn = $inviteeFqdn
-
-            }
-            $ConfigJson = $inviteeDetails | ConvertTo-Json
-            $response = Invoke-RestMethod -Method POST -URI $uri -headers $headers -body $ConfigJson -ContentType 'application/json'
-            $response
+            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
     }
     Catch {
@@ -2196,7 +2226,7 @@ Function Join-VCFFederation {
         Federation (Multi-Instance configuration).
 
         .EXAMPLE
-        PS C:\> Join-VCFFederation -json .\joinVCFFederationSpec.json
+        Join-VCFFederation -json .\joinVCFFederationSpec.json
         This example demonstrates how to join an VCF Federation by referencing config info in JSON file.
     #>
 
@@ -2204,26 +2234,32 @@ Function Join-VCFFederation {
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$json
     )
 
-    if (!(Test-Path $json)) {
-        Throw "JSON File Not Found"
-    }
-    else {
-        $ConfigJson = (Get-Content -Raw $json) # Reads the joinSVCFFederation json file contents into the $ConfigJson variable
-        createHeader # Calls createHeader function to set Accept & Authorization
-        checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
-        $uri = "https://$sddcManager/v1/sddc-federation/members"
-        Try {
-            $response = Invoke-RestMethod -Method POST -URI $uri -headers $headers -ContentType 'application/json' -body $ConfigJson
-            $response
-            $taskId = $response.taskId # get the task id from the action
-            # keep checking until executionStatus is not IN_PROGRESS
-            Do {
-                $uri = "https://$sddcManager/v1/sddc-federation/tasks/$taskId"
-                $response = Invoke-RestMethod -Method GET -URI $uri -Headers $headers -ContentType 'application/json'
-                Start-Sleep -Second 5
+    Try {
+        $vcfVersion = ((Get-VCFManager).version -Split ('\.\d{1}\-\d{8}')) -split '\s+' -match '\S'
+        if ($vcfVersion -lt "4.4.0") {
+            if (!(Test-Path $json)) {
+                Throw "JSON File Not Found"
             }
-            While ($response.status -eq "IN_PROGRESS")
-            $response
+            else {
+                $ConfigJson = (Get-Content -Raw $json) # Reads the joinSVCFFederation json file contents into the $ConfigJson variable
+                createHeader # Calls createHeader function to set Accept & Authorization
+                checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
+                $uri = "https://$sddcManager/v1/sddc-federation/members"
+                $response = Invoke-RestMethod -Method POST -URI $uri -headers $headers -ContentType 'application/json' -body $ConfigJson
+                $response
+                $taskId = $response.taskId # get the task id from the action
+                # keep checking until executionStatus is not IN_PROGRESS
+                Do {
+                    $uri = "https://$sddcManager/v1/sddc-federation/tasks/$taskId"
+                    $response = Invoke-RestMethod -Method GET -URI $uri -Headers $headers -ContentType 'application/json'
+                    Start-Sleep -Second 5
+                }
+                While ($response.status -eq "IN_PROGRESS")
+                $response
+            }
+        }
+        else {
+            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
         Catch {
             ResponseException -object $_
@@ -4187,7 +4223,7 @@ Export-ModuleMember -Function Get-VCFvRA
 Function Get-VCFvRLI {
     <#
         .SYNOPSIS
-        Get the existing vRealize Log Insight
+        Get the existi  ng vRealize Log Insight
 
         .DESCRIPTION
         The Get-VCFvRLI cmdlet gets the complete information about the existing vRealize Log Insight.

--- a/PowerVCF.psm1
+++ b/PowerVCF.psm1
@@ -2261,9 +2261,9 @@ Function Join-VCFFederation {
         else {
             Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
-        Catch {
-            ResponseException -object $_
-        }
+    }
+    Catch {
+        ResponseException -object $_
     }
 }
 Export-ModuleMember -Function Join-VCFFederation
@@ -2283,16 +2283,16 @@ Function Get-VCFNsxtCluster {
         The Get-VCFNsxtCluster cmdlet retrieves a list of NSX-T Clusters managed by the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFNsxtCluster
+        Get-VCFNsxtCluster
         This example shows how to get the list of NSX-T Clusters managed by the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFNsxtCluster -id d189a789-dbf2-46c0-a2de-107cde9f7d24
+        Get-VCFNsxtCluster -id d189a789-dbf2-46c0-a2de-107cde9f7d24
         This example shows how to return the details for a specic NSX-T Clusters managed by the connected SDDC Manager
         using the ID
 
         .EXAMPLE
-        PS C:\> Get-VCFNsxtCluster | select vipfqdn
+        Get-VCFNsxtCluster | select vipfqdn
         This example shows how to get the list of NSX-T Clusters managed by the connected SDDC Manager but only return the vipfqdn
     #>
 
@@ -2335,15 +2335,15 @@ Function Get-VCFNetworkPool {
         The Get-VCFNetworkPool cmdlet connects to the specified SDDC Manager & retrieves a list of Network Pools.
 
         .EXAMPLE
-        PS C:\> Get-VCFNetworkPool
+        Get-VCFNetworkPool
         This example shows how to get a list of all Network Pools
 
         .EXAMPLE
-        PS C:\> Get-VCFNetworkPool -name sfo01-networkpool
+        Get-VCFNetworkPool -name sfo01-networkpool
         This example shows how to get a Network Pool by name
 
         .EXAMPLE
-        PS C:\> Get-VCFNetworkPool -id 40b0b36d-36d6-454c-814b-ba8bf9b383e3
+        Get-VCFNetworkPool -id 40b0b36d-36d6-454c-814b-ba8bf9b383e3
         This example shows how to get a Network Pool by id
     #>
 
@@ -2387,7 +2387,7 @@ Function New-VCFNetworkPool {
         Network Pool spec is provided in a JSON file.
 
         .EXAMPLE
-        PS C:\> New-VCFNetworkPool -json .\NetworkPool\createNetworkPoolSpec.json
+        New-VCFNetworkPool -json .\NetworkPool\createNetworkPoolSpec.json
         This example shows how to create a Network Pool
     #>
 
@@ -2421,7 +2421,7 @@ Function Remove-VCFNetworkPool {
         The Remove-VCFNetworkPool cmdlet connects to the specified SDDC Manager & deletes a Network Pool
 
         .EXAMPLE
-        PS C:\> Remove-VCFNetworkPool -id 7ee7c7d2-5251-4bc9-9f91-4ee8d911511f
+        Remove-VCFNetworkPool -id 7ee7c7d2-5251-4bc9-9f91-4ee8d911511f
         This example shows how to get a Network Pool by id
     #>
 
@@ -2451,11 +2451,11 @@ Function Get-VCFNetworkIPPool {
         configured for the provided network pool.
 
         .EXAMPLE
-        PS C:\> Get-VCFNetworkIPPool -id 917bcf8f-93e8-4b84-9627-471899c05f52
+        Get-VCFNetworkIPPool -id 917bcf8f-93e8-4b84-9627-471899c05f52
         This example shows how to get a list of all networks associated to the network pool based on the id provided
 
         .EXAMPLE
-        PS C:\> Get-VCFNetworkIPPool -id 917bcf8f-93e8-4b84-9627-471899c05f52 -networkid c2197368-5b7c-4003-80e5-ff9d3caef795
+        Get-VCFNetworkIPPool -id 917bcf8f-93e8-4b84-9627-471899c05f52 -networkid c2197368-5b7c-4003-80e5-ff9d3caef795
         This example shows how to get a list of details for a specific network associated to the network pool using ids
     #>
 
@@ -2494,7 +2494,7 @@ Function Add-VCFNetworkIPPool {
         to an existing Network within a Network Pool.
 
         .EXAMPLE
-        PS C:\> Add-VCFNetworkIPPool -id 917bcf8f-93e8-4b84-9627-471899c05f52 -networkid c2197368-5b7c-4003-80e5-ff9d3caef795 -ipStart 192.168.110.61 -ipEnd 192.168.110.64
+        Add-VCFNetworkIPPool -id 917bcf8f-93e8-4b84-9627-471899c05f52 -networkid c2197368-5b7c-4003-80e5-ff9d3caef795 -ipStart 192.168.110.61 -ipEnd 192.168.110.64
         This example shows how create a new IP Pool on the existing network for a given Network Pool
     #>
 
@@ -2529,7 +2529,7 @@ Function Remove-VCFNetworkIPPool {
         existing Network within a Network Pool.
 
         .EXAMPLE
-        PS C:\> Remove-VCFNetworkIPPool -id 917bcf8f-93e8-4b84-9627-471899c05f52 -networkid c2197368-5b7c-4003-80e5-ff9d3caef795 -ipStart 192.168.110.61 -ipEnd 192.168.110.64
+        Remove-VCFNetworkIPPool -id 917bcf8f-93e8-4b84-9627-471899c05f52 -networkid c2197368-5b7c-4003-80e5-ff9d3caef795 -ipStart 192.168.110.61 -ipEnd 192.168.110.64
         This example shows how remove an IP Pool on the existing network for a given Network Pool
     #>
 
@@ -2569,11 +2569,11 @@ Function Get-VCFEdgeCluster {
         The Get-VCFEdgeCluster cmdlet gets a list of NSX-T Edge Clusters
 
         .EXAMPLE
-        PS C:\> Get-VCFEdgeCluster
+        Get-VCFEdgeCluster
         This example list all NSX-T Edge Clusters
 
         .EXAMPLE
-        PS C:\> Get-VCFEdgeCluster -id b4e3b2c4-31e8-4816-b1c5-801e848bef09
+        Get-VCFEdgeCluster -id b4e3b2c4-31e8-4816-b1c5-801e848bef09
         This example list the NSX-T Edge Cluster by id
     #>
 
@@ -2610,11 +2610,11 @@ Function New-VCFEdgeCluster {
         The New-VCFEdgeCluster cmdlet connects to the specified SDDC Manager & creates an NSX-T edge cluster.
 
         .EXAMPLE
-        PS C:\> New-VCFEdgeCluster -json .\SampleJSON\EdgeCluster\edgeClusterSpec.json
+        New-VCFEdgeCluster -json .\SampleJSON\EdgeCluster\edgeClusterSpec.json
         This example shows how to create an NSX-T edge cluster from a json spec
 
         .EXAMPLE
-        PS C:\> New-VCFEdgeCluster -json .\SampleJSON\EdgeCluster\edgeClusterSpec.json -validate
+        New-VCFEdgeCluster -json .\SampleJSON\EdgeCluster\edgeClusterSpec.json -validate
         This example shows how to validate the JSON spec for Edge Cluster creation
     #>
 
@@ -2686,11 +2686,11 @@ Function Get-VCFPersonality {
         The Get-VCFPersonality cmdlet gets the vSphere Lifecycle Manager personalities which are available via depot access
 
         .EXAMPLE
-        PS C:\> Get-VCFPersonality
+        Get-VCFPersonality
         This example list all the vSphere Lifecycle Manager personalities availble in the depot
 
         .EXAMPLE
-        PS C:\> Get-VCFPersonality -id b4e3b2c4-31e8-4816-b1c5-801e848bef09
+        Get-VCFPersonality -id b4e3b2c4-31e8-4816-b1c5-801e848bef09
         This example gets a vSphere Lifecycle Manager personality by ID
     #>
 
@@ -2733,7 +2733,7 @@ Function Get-VCFFederationTask {
         The Get-VCFFederationTask cmdlet gets the status of tasks relating to Federation operations
 
         .EXAMPLE
-        PS C:\> Get-VCFFederationTask -id f6f38f6b-da0c-4ef9-9228-9330f3d30279
+        Get-VCFFederationTask -id f6f38f6b-da0c-4ef9-9228-9330f3d30279
         This example list all tasks for Federation operations
     #>
 
@@ -2742,11 +2742,17 @@ Function Get-VCFFederationTask {
     )
 
     Try {
-        createHeader # Calls createHeader function to set Accept & Authorization
-        checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
-        $uri = "https://$sddcManager/v1/sddc-federation/tasks/$id"
-        $response = Invoke-RestMethod -Method GET -URI $uri -headers $headers
-        $response
+        $vcfVersion = ((Get-VCFManager).version -Split ('\.\d{1}\-\d{8}')) -split '\s+' -match '\S'
+        if ($vcfVersion -lt "4.4.0") {
+            createHeader # Calls createHeader function to set Accept & Authorization
+            checkVCFToken # Calls the CheckVCFToken function to validate the access token and refresh if necessary
+            $uri = "https://$sddcManager/v1/sddc-federation/tasks/$id"
+            $response = Invoke-RestMethod -Method GET -URI $uri -headers $headers
+            $response
+        }
+        else {
+            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
+        }
     }
     Catch {
         ResponseException -object $_
@@ -2769,11 +2775,11 @@ Function Get-CloudBuilderSDDC {
         The Get-CloudBuilderSDDC cmdlet gets a list of SDDC deployments from Cloud Builder
 
         .EXAMPLE
-        PS C:\> Get-CloudBuilderSDDC
+        Get-CloudBuilderSDDC
         This example list all SDDC deployments from Cloud Builder
 
         .EXAMPLE
-        PS C:\> Get-CloudBuilderSDDC -id 51cc2d90-13b9-4b62-b443-c1d7c3be0c23
+        Get-CloudBuilderSDDC -id 51cc2d90-13b9-4b62-b443-c1d7c3be0c23
         This example gets the SDDC deployment with a specific ID from Cloud Builder
     #>
 
@@ -2809,7 +2815,7 @@ Function Start-CloudBuilderSDDC {
         The Start-CloudBuilderSDDC cmdlet starts the deployment based on the SddcSpec.json provided
 
         .EXAMPLE
-        PS C:\> Start-CloudBuilderSDDC -json .\SampleJSON\SDDC\SddcSpec.json
+        Start-CloudBuilderSDDC -json .\SampleJSON\SDDC\SddcSpec.json
         This example starts the deployment using the SddcSpec.json
     #>
 
@@ -2839,11 +2845,11 @@ Function Restart-CloudBuilderSDDC {
         The Restart-CloudBuilderSDDC retries a deployment on Cloud Builder
 
         .EXAMPLE
-        PS C:\> Restart-CloudBuilderSDDC -id bedf19f8-9dfe-4c60-aae4-bca986a65a31
+        Restart-CloudBuilderSDDC -id bedf19f8-9dfe-4c60-aae4-bca986a65a31
         This example retries a deployment on Cloud Builder based on the ID
 
         .EXAMPLE
-        PS C:\> Restart-CloudBuilderSDDC -id bedf19f8-9dfe-4c60-aae4-bca986a65a31 -json .\SampleJSON\SDDC\SddcSpec.json
+        Restart-CloudBuilderSDDC -id bedf19f8-9dfe-4c60-aae4-bca986a65a31 -json .\SampleJSON\SDDC\SddcSpec.json
         This example retries a deployment on Cloud Builder based on the ID with an updated JSON file
     #>
 
@@ -2881,11 +2887,11 @@ Function Get-CloudBuilderSDDCValidation {
         The Get-CloudBuilderSDDCValidation cmdlet gets a list of SDDC validations from Cloud Builder
 
         .EXAMPLE
-        PS C:\> Get-CloudBuilderSDDCValidation
+        Get-CloudBuilderSDDCValidation
         This example list all SDDC validations from Cloud Builder
 
         .EXAMPLE
-        PS C:\> Get-CloudBuilderSDDCValidation -id 1ff80635-b878-441a-9e23-9369e1f6e5a3
+        Get-CloudBuilderSDDCValidation -id 1ff80635-b878-441a-9e23-9369e1f6e5a3
         This example gets the SDDC validation with a specific ID from Cloud Builder
     #>
 
@@ -2921,11 +2927,11 @@ Function Start-CloudBuilderSDDCValidation {
         The Start-CloudBuilderSDDCValidation cmdlet performs validation of the SddcSpec.json provided
 
         .EXAMPLE
-        PS C:\> Start-CloudBuilderSDDCValidation -json .\SampleJSON\SDDC\SddcSpec.json
+        Start-CloudBuilderSDDCValidation -json .\SampleJSON\SDDC\SddcSpec.json
         This example starts the validation of the SddcSpec.json
 
         .EXAMPLE
-        PS C:\> Start-CloudBuilderSDDCValidation -json .\SampleJSON\SDDC\SddcSpec.json -validation LICENSE_KEY_VALIDATION
+        Start-CloudBuilderSDDCValidation -json .\SampleJSON\SDDC\SddcSpec.json -validation LICENSE_KEY_VALIDATION
         This example starts the validation of the License Key items only based on the SddcSpec.json json
     #>
 
@@ -2963,7 +2969,7 @@ Function Stop-CloudBuilderSDDCValidation {
         The Stop-CloudBuilderSDDCValidation cancels a validation in progress on Cloud Builder
 
         .EXAMPLE
-        PS C:\> Stop-CloudBuilderSDDCValidation -id bedf19f8-9dfe-4c60-aae4-bca986a65a31
+        Stop-CloudBuilderSDDCValidation -id bedf19f8-9dfe-4c60-aae4-bca986a65a31
         This example stops a validation that is running on Cloud Builder based on the ID
     #>
 
@@ -2992,7 +2998,7 @@ Function Restart-CloudBuilderSDDCValidation {
         The Restart-CloudBuilderSDDCValidation reties a validation on Cloud Builder
 
         .EXAMPLE
-        PS C:\> Restart-CloudBuilderSDDCValidation -id bedf19f8-9dfe-4c60-aae4-bca986a65a31
+        Restart-CloudBuilderSDDCValidation -id bedf19f8-9dfe-4c60-aae4-bca986a65a31
         This example retries a validation on Cloud Builder based on the ID
     #>
 
@@ -3027,15 +3033,15 @@ Function Get-VCFManager {
         The Get-VCFManager cmdlet retrieves the SDDC Manager details
 
         .EXAMPLE
-        PS C:\> Get-VCFManager
+        Get-VCFManager
         This example shows how to retrieve a list of SDDC Managers
 
         .EXAMPLE
-        PS C:\> Get-VCFManager -id 60d6b676-47ae-4286-b4fd-287a888fb2d0
+        Get-VCFManager -id 60d6b676-47ae-4286-b4fd-287a888fb2d0
         This example shows how to return the details for a specific SDDC Manager based on the ID
 
         .EXAMPLE
-        PS C:\> Get-VCFManager -domain 1a6291f2-ed54-4088-910f-ead57b9f9902
+        Get-VCFManager -domain 1a6291f2-ed54-4088-910f-ead57b9f9902
         This example shows how to return the details for a specific SDDC Manager based on a domain ID
     #>
 
@@ -3084,7 +3090,7 @@ Function Start-VCFSystemPrecheck {
         The Start-VCFSystemPrecheck cmdlet performs system level health checks and upgrade pre-checks for an upgrade to be successful
 
         .EXAMPLE
-        PS C:\> Start-VCFSystemPrecheck -json .\SystemCheck\precheckVCFSystem.json
+        Start-VCFSystemPrecheck -json .\SystemCheck\precheckVCFSystem.json
         This example shows how to perform system level health check
     #>
 
@@ -3114,7 +3120,7 @@ Function Get-VCFSystemPrecheckTask {
         The Get-VCFSystemPrecheckTask cmdlet performs retrieval of a system precheck task that can be polled and monitored.
 
         .EXAMPLE
-        PS C:\> Get-VCFSystemPrecheckTask -id 4d661acc-2be6-491d-9256-ba3c78020e5d
+        Get-VCFSystemPrecheckTask -id 4d661acc-2be6-491d-9256-ba3c78020e5d
         This example shows how to retrieve the status of a system level precheck task
     #>
 
@@ -3150,15 +3156,15 @@ Function Get-VCFTask {
         The Get-VCFTask cmdlet connects to the specified SDDC Manager and retrieves a list of tasks.
 
         .EXAMPLE
-        PS C:\> Get-VCFTask
+        Get-VCFTask
         This example shows how to get all tasks
 
         .EXAMPLE
-        PS C:\> Get-VCFTask -id 7e1c2eee-3177-4e3b-84db-bfebc83f386a
+        Get-VCFTask -id 7e1c2eee-3177-4e3b-84db-bfebc83f386a
         This example shows how to get a task by id
 
         .EXAMPLE
-        PS C:\> Get-VCFTask -status SUCCESSFUL
+        Get-VCFTask -status SUCCESSFUL
         This example shows how to get all tasks with a status of SUCCESSFUL
     #>
 
@@ -3209,7 +3215,7 @@ Function Restart-VCFTask {
         failed task using the task id.
 
         .EXAMPLE
-        PS C:\> Restart-VCFTask -id 7e1c2eee-3177-4e3b-84db-bfebc83f386a
+        Restart-VCFTask -id 7e1c2eee-3177-4e3b-84db-bfebc83f386a
         This example retries the task based on the task id
     #>
 
@@ -3251,7 +3257,7 @@ Function Get-VCFUpgradable {
         The Upgradables provides information that can be use for Precheck API and also in the actual Upgrade API call.
 
         .EXAMPLE
-        PS C:\> Get-VCFUpgradable
+        Get-VCFUpgradable
         This example shows how to retrieve the list of upgradables in the system
     #>
 
@@ -3283,7 +3289,7 @@ Function Get-VCFUpgrade {
         The Get-VCFUpgrade cmdlet retrives a list of upgradable resources in SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFUpgrade
+        Get-VCFUpgrade
         This example shows how to retrieve the list of upgradable resources in the system
     #>
 
@@ -3320,11 +3326,11 @@ Function Start-VCFUpgrade {
         The Start-VCFUpgrade cmdlet triggers an upgrade of a resource in SDDC Manager
 
         .EXAMPLE
-        PS C:\> Start-VCFUpgrade -json $jsonSpec
+        Start-VCFUpgrade -json $jsonSpec
         This example invokes an upgrade in SDDC Manager using a variable
 
         .EXAMPLE
-        PS C:\> Start-VCFUpgrade -json (Get-Content -Raw .\upgradeDomain.json)
+        Start-VCFUpgrade -json (Get-Content -Raw .\upgradeDomain.json)
         This example invokes an upgrade in SDDC Manager by passing a JSON file
 
     #>
@@ -3361,23 +3367,23 @@ Function Get-VCFUser {
         The Get-VCFUser cmdlet gets a list of users, groups and service users in SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFUser
+        Get-VCFUser
         This example list all users, groups and service users in SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFUser -type USER
+        Get-VCFUser -type USER
         This example list all users in SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFUser -type GROUP
+        Get-VCFUser -type GROUP
         This example list all groups in SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFUser -type SERVICE
+        Get-VCFUser -type SERVICE
         This example list all service users in SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFUser -domain rainpole.io
+        Get-VCFUser -domain rainpole.io
         This example list all users and groups based on the authentication domain provided in SDDC Manager
     #>
 
@@ -3416,7 +3422,7 @@ Function New-VCFUser {
         The New-VCFUser cmdlet connects to the specified SDDC Manager and adds a new user with a specified role.
 
         .EXAMPLE
-        PS C:\> New-VCFUser -user vcf-admin@rainpole.io -role ADMIN
+        New-VCFUser -user vcf-admin@rainpole.io -role ADMIN
         This example shows how to add a new user with a specified role
     #>
 
@@ -3433,12 +3439,12 @@ Function New-VCFUser {
         $roleID = Get-VCFRole | Where-object { $_.name -eq $role } | Select-Object -ExpandProperty id
         $domain = $user.split('@')
         $body = '[ {
-          "name" : "'+ $user + '",
-          "domain" : "'+ $domain[1] + '",
-          "type" : "USER",
-          "role" : {
+            "name" : "'+ $user + '",
+            "domain" : "'+ $domain[1] + '",
+            "type" : "USER",
+            "role" : {
             "id" : "'+ $roleID + '"
-          }
+            }
         }]'
         $response = Invoke-RestMethod -Method POST -URI $uri -headers $headers -ContentType application/json -body $body
         $response.elements
@@ -3477,8 +3483,8 @@ Function New-VCFServiceUser {
             "name" : "'+ $user + '",
             "type" : "SERVICE",
             "role" : {
-              "id" : "'+ $roleID + '"
-            }
+            "id" : "'+ $roleID + '"
+        }
         }]'
         $response = Invoke-RestMethod -Method POST -URI $uri -headers $headers -ContentType application/json -body $body
         $response.elements
@@ -3498,7 +3504,7 @@ Function Get-VCFRole {
         The Get-VCFRole cmdlet gets a list of roles in SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFRole
+        Get-VCFRole
         This example list all roles in SDDC Manager
     #>
 
@@ -3524,7 +3530,7 @@ Function Remove-VCFUser {
         The Remove-VCFUser cmdlet connects to the specified SDDC Manager and deletes a user
 
         .EXAMPLE
-        PS C:\> Remove-VCFUser -id c769fcc5-fb61-4d05-aa40-9c7786163fb5
+        Remove-VCFUser -id c769fcc5-fb61-4d05-aa40-9c7786163fb5
         This example shows how to delete a user
     #>
 
@@ -3554,7 +3560,7 @@ Function New-VCFGroup {
         The New-VCFGroup cmdlet connects to the specified SDDC Manager and adds a new group with a specified role
 
         .EXAMPLE
-        PS C:\> New-VCFGroup -group ug-vcf-group -domain rainpole.io -role ADMIN
+        New-VCFGroup -group ug-vcf-group -domain rainpole.io -role ADMIN
         This example shows how to add a new group with a specified role
     #>
 
@@ -3572,12 +3578,12 @@ Function New-VCFGroup {
         $roleID = Get-VCFRole | Where-object { $_.name -eq $role } | Select-Object -ExpandProperty id
         #$domain = $user.split('@')
         $body = '[{
-          "name" : "'+ $group + '",
-          "domain" : "'+ $domain.ToUpper() + '",
-          "type" : "GROUP",
-          "role" : {
+            "name" : "'+ $group + '",
+            "domain" : "'+ $domain.ToUpper() + '",
+            "type" : "GROUP",
+            "role" : {
             "id" : "'+ $roleID + '"
-          }
+        }
         }]'
         $response = Invoke-RestMethod -Method POST -URI $uri -headers $headers -ContentType application/json -body $body
         $response.elements
@@ -3656,7 +3662,7 @@ Function Get-VCFConfigurationDNS {
         The Get-VCFConfigurationDNS cmdlet retrieves the DNS configuration of the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFConfigurationDNS
+        Get-VCFConfigurationDNS
         This example shows how to get the DNS configuration of the connected SDDC Manager
     #>
 
@@ -3683,7 +3689,7 @@ Function Get-VCFConfigurationDNSValidation {
         JSON
 
         .EXAMPLE
-        PS C:\> Get-VCFConfigurationDNSValidation
+        Get-VCFConfigurationDNSValidation
         This example shows how to get the status of the validation of the DNS Configuration
     #>
 
@@ -3713,15 +3719,15 @@ Function Set-VCFConfigurationDNS {
         The Set-VCFConfigurationDNS cmdlet configures the DNS Server for all systems managed by SDDC Manager
 
         .EXAMPLE
-        PS C:\> Set-VCFConfigurationDNS -json $jsonSpec
+        Set-VCFConfigurationDNS -json $jsonSpec
         This example shows how to configure the DNS Servers for all systems managed by SDDC Manager using a variable
 
-       .EXAMPLE
-        PS C:\> Set-VCFConfigurationDNS -json (Get-Content -Raw .\dnsSpec.json)
+        .EXAMPLE
+        Set-VCFConfigurationDNS -json (Get-Content -Raw .\dnsSpec.json)
         This example shows how to configure the DNS Servers for all systems managed by SDDC Manager using a JSON file
 
         .EXAMPLE
-        PS C:\> Set-VCFConfigurationDNS -json $jsonSpec -validate
+        Set-VCFConfigurationDNS -json $jsonSpec -validate
         This example shows how to validate the DNS configuration only
     #>
 
@@ -3759,7 +3765,7 @@ Function Get-VCFConfigurationNTP {
         The Get-VCFConfigurationNTP cmdlet retrieves the NTP configuration of the connected SDDC Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFConfigurationNTP
+        Get-VCFConfigurationNTP
         This example shows how to get the NTP configuration of the connected SDDC Manager
     #>
 
@@ -3786,7 +3792,7 @@ Function Get-VCFConfigurationNTPValidation {
         JSON
 
         .EXAMPLE
-        PS C:\> Get-VCFConfigurationNTPValidation
+        Get-VCFConfigurationNTPValidation
         This example shows how to get the status of the validation of the NTP Configuration
     #>
 
@@ -3816,15 +3822,15 @@ Function Set-VCFConfigurationNTP {
         The Set-VCFConfigurationNTP cmdlet configures the NTP Server for all systems managed by SDDC Manager
 
         .EXAMPLE
-        PS C:\> Set-VCFConfigurationNTP -json $jsonSpec
+        Set-VCFConfigurationNTP -json $jsonSpec
         This example shows how to configure the NTP Servers for all systems managed by SDDC Manager using a variable
 
-       .EXAMPLE
-        PS C:\> Set-VCFConfigurationNTP (Get-Content -Raw .\ntpSpec.json)
+        .EXAMPLE
+        Set-VCFConfigurationNTP (Get-Content -Raw .\ntpSpec.json)
         This example shows how to configure the NTP Servers for all systems managed by SDDC Manager using a JSON file
 
         .EXAMPLE
-        PS C:\> Set-VCFConfigurationNTP -json $jsonSpec -validate
+        Set-VCFConfigurationNTP -json $jsonSpec -validate
         This example shows how to validate the NTP configuration only
     #>
 
@@ -3861,30 +3867,30 @@ Export-ModuleMember -Function Set-VCFConfigurationNTP
 
 Function Get-VCFvCenter {
     <#
-    .SYNOPSIS
-    Gets a list of vCenter Servers
+        .SYNOPSIS
+        Gets a list of vCenter Servers
 
-    .DESCRIPTION
-    Retrieves a list of vCenter Servers managed by the connected SDDC Manager
+        .DESCRIPTION
+        Retrieves a list of vCenter Servers managed by the connected SDDC Manager
 
-    .EXAMPLE
-    PS C:\> Get-VCFvCenter
-    This example shows how to get the list of vCenter Servers managed by the connected SDDC Manager
+        .EXAMPLE
+        Get-VCFvCenter
+        This example shows how to get the list of vCenter Servers managed by the connected SDDC Manager
 
-    .EXAMPLE
-    PS C:\> Get-VCFvCenter -id d189a789-dbf2-46c0-a2de-107cde9f7d24
-    This example shows how to return the details for a specific vCenter Server managed by the connected SDDC Manager
-    using its id
+        .EXAMPLE
+        Get-VCFvCenter -id d189a789-dbf2-46c0-a2de-107cde9f7d24
+        This example shows how to return the details for a specific vCenter Server managed by the connected SDDC Manager
+        using its id
 
-    .EXAMPLE
-    PS C:\> Get-VCFvCenter -domain 1a6291f2-ed54-4088-910f-ead57b9f9902
-    This example shows how to return the details off all vCenter Server managed by the connected SDDC Manager using
-    its domainId
+        .EXAMPLE
+        Get-VCFvCenter -domain 1a6291f2-ed54-4088-910f-ead57b9f9902
+        This example shows how to return the details off all vCenter Server managed by the connected SDDC Manager using
+        its domainId
 
-    .EXAMPLE
-    PS C:\> Get-VCFvCenter | select fqdn
-    This example shows how to get the list of vCenter Servers managed by the connected SDDC Manager but only return the fqdn
-  #>
+        .EXAMPLE
+        Get-VCFvCenter | select fqdn
+        This example shows how to get the list of vCenter Servers managed by the connected SDDC Manager but only return the fqdn
+    #>
 
     Param (
         [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [String]$id,
@@ -3931,7 +3937,7 @@ Function Get-VCFvRSLCM {
         The Get-VCFvRSLCM cmdlet gets the complete information about the existing vRealize Suite Lifecycle Manager.
 
         .EXAMPLE
-        PS C:\> Get-VCFvRSLCM
+        Get-VCFvRSLCM
         This example list all details concerning the vRealize Suite Lifecycle Manager
     #>
 
@@ -3957,11 +3963,11 @@ Function New-VCFvRSLCM {
         The New-VCFvRSLCM cmdlet deploys vRealize Suite Lifecycle Manager to the specified network.
 
         .EXAMPLE
-        PS C:\> New-VCFvRSLCM -json .\SampleJson\vRealize\New-VCFvRSLCM-AVN.json
+        New-VCFvRSLCM -json .\SampleJson\vRealize\New-VCFvRSLCM-AVN.json
         This example deploys vRealize Suite Lifecycle Manager using a supplied json file
 
         .EXAMPLE
-        PS C:\> New-VCFvRSLCM -json .\SampleJson\vRealize\New-VCFvRSLCM-AVN.json -validate
+        New-VCFvRSLCM -json .\SampleJson\vRealize\New-VCFvRSLCM-AVN.json -validate
         This example performs validation of vRealize Suite Lifecycle Manager using a supplied json file
     #>
 
@@ -4006,7 +4012,7 @@ Function Remove-VCFvRSLCM {
         to a successful vRealize Suite Lifecycle Manager deployment.
 
         .EXAMPLE
-        PS C:\> Remove-VCFvRSLCM
+        Remove-VCFvRSLCM
         This example removes a failed vRealize Suite Lifecycle Manager deployment
     #>
 
@@ -4032,7 +4038,7 @@ Function Reset-VCFvRSLCM {
         The Reset-VCFvRSLCM cmdlet redeploys the existing vRealize Suite Lifecycle Manager
 
         .EXAMPLE
-        PS C:\> Reset-VCFvRSLCM
+        Reset-VCFvRSLCM
         This example redeploys the vRealize Suite Lifecycle Manager
     #>
 
@@ -4062,11 +4068,11 @@ Function Get-VCFvROPS {
         The Get-VCFvROPs cmdlet gets the complete information about the existing vRealize Operations Manager.
 
         .EXAMPLE
-        PS C:\> Get-VCFvROPs
+        Get-VCFvROPs
         This example list all details concerning the vRealize Operations Manager
 
         .EXAMPLE
-        PS C:\> Get-VCFvROPs -domains
+        Get-VCFvROPs -domains
         This example lists all workload domains connected to vRealize Operations Manager
     #>
 
@@ -4129,11 +4135,11 @@ Function Set-VCFvROPSConnection {
         The Set-VCFvROPs cmdlet connects or disconnects Workload Domains to vRealize Operations Manager.
 
         .EXAMPLE
-        PS C:\> Set-VCFvROPs -domainId <domain-id> -status ENABLED
+        Set-VCFvROPs -domainId <domain-id> -status ENABLED
         This example connects a Workload Domain to vRealize Operations Manager
 
         .EXAMPLE
-        PS C:\> Set-VCFvROPs -domainId <domain-id> -status DISABLED
+        Set-VCFvROPs -domainId <domain-id> -status DISABLED
         This example disconnects a Workload Domain from vRealize Operations Manager
     #>
 
@@ -4169,7 +4175,7 @@ Function Get-VCFWSA {
         The Get-VCFWSA cmdlet gets the complete information about the existing Workspace ONE Access.
 
         .EXAMPLE
-        PS C:\> Get-VCFWSA
+        Get-VCFWSA
         This example list all details concerning Workspace ONE Access
     #>
 
@@ -4199,7 +4205,7 @@ Function Get-VCFvRA {
         The Get-VCFvRA cmdlet gets the complete information about the existing vRealize Automation.
 
         .EXAMPLE
-        PS C:\> Get-VCFvRA
+        Get-VCFvRA
         This example list all details concerning the vRealize Automation
     #>
 
@@ -4229,7 +4235,7 @@ Function Get-VCFvRLI {
         The Get-VCFvRLI cmdlet gets the complete information about the existing vRealize Log Insight.
 
         .EXAMPLE
-        PS C:\> Get-VCFvRLI
+        Get-VCFvRLI
         This example list all details concerning the vRealize Log Insight
     #>
 

--- a/PowerVCF.psm1
+++ b/PowerVCF.psm1
@@ -1698,7 +1698,7 @@ Function Get-VCFFederation {
             $response
         }
         else {
-            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
+            Write-Warning "Multi-Instance Management has been deprecated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
     }
     Catch {
@@ -1738,7 +1738,7 @@ Function Set-VCFFederation {
             $response
         }
         else {
-            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
+            Write-Warning "Multi-Instance Management has been deprecated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
     }
     Catch {
@@ -1787,7 +1787,7 @@ Function Remove-VCFFederation {
             $response
         }
         else {
-            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
+            Write-Warning "Multi-Instance Management has been deprecated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
     }
     Catch {
@@ -2158,7 +2158,7 @@ Function Get-VCFFederationMember {
             }
         }
         else {
-            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
+            Write-Warning "Multi-Instance Management has been deprecated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
     }
     Catch {
@@ -2207,7 +2207,7 @@ Function New-VCFFederationInvite {
             }
         }
         else {
-            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
+            Write-Warning "Multi-Instance Management has been deprecated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
     }
     Catch {
@@ -2259,7 +2259,7 @@ Function Join-VCFFederation {
             }
         }
         else {
-            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
+            Write-Warning "Multi-Instance Management has been deprecated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
     }
     Catch {
@@ -2751,7 +2751,7 @@ Function Get-VCFFederationTask {
             $response
         }
         else {
-            Write-Warning "Multi-Instance Management has been depricated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
+            Write-Warning "Multi-Instance Management has been deprecated in VMware Cloud Foundation v4.4.0 and later, this API is no longer supported"
         }
     }
     Catch {


### PR DESCRIPTION
- Fixed `Get-VCFApplicationVirtualNetwork`cmdlet when passing the ID of the Application Virtual Network the response was failing. Closes #135
- Updated `Get-VCFFederation` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
- Updated `Set-VCFFederation` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
- Updated `Remove-VCFFederation` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
- Updated `Get-VCFFederationMember` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
- Updated `New-VCFFederationInvite` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
- Updated `Join-VCFFederation` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.
- - Updated `Get-VCFFederationTask` cmdlet to check the system version, multi-instance management is deprecated in VMware Cloud Foundation v4.4.0.

Signed-off-by: Gary Blake <gblake@vmware.com>